### PR TITLE
Add registry test coverage and fix six surfaced defects

### DIFF
--- a/cmd/api-gateway/routes/admin_routes_test.go
+++ b/cmd/api-gateway/routes/admin_routes_test.go
@@ -1,0 +1,75 @@
+package routes
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+// makeAdmin flips the harness user to admin. AuthMiddleware reloads the user from
+// the DB on every request, so the existing token keeps working.
+func makeAdmin(t *testing.T, h *testHarness) {
+	t.Helper()
+	require.NoError(t, h.db.DB.Model(&types.User{}).
+		Where("id = ?", h.user.ID).Update("is_admin", true).Error)
+}
+
+func TestAdminRegistrySettings(t *testing.T) {
+	h := newHarness(t)
+	makeAdmin(t, h)
+	AdminRoutes(h.api, h.registry, h.auth)
+
+	// List all.
+	w := h.do(http.MethodGet, "/api/admin/registries/", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "npm")
+
+	// Get one.
+	w = h.do(http.MethodGet, "/api/admin/registries/npm", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Unknown registry.
+	w = h.do(http.MethodGet, "/api/admin/registries/ghost", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAdminEnableDisableDescribe(t *testing.T) {
+	h := newHarness(t)
+	makeAdmin(t, h)
+	AdminRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodPut, "/api/admin/registries/npm/disable", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = h.do(http.MethodPut, "/api/admin/registries/npm/enable", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = h.do(http.MethodPut, "/api/admin/registries/npm/description",
+		[]byte(`{"description":"node packages"}`), "application/json")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Missing required description.
+	w = h.do(http.MethodPut, "/api/admin/registries/npm/description",
+		[]byte(`{}`), "application/json")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminForbiddenForNonAdmin(t *testing.T) {
+	h := newHarness(t)
+	AdminRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/admin/registries/", nil, "")
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestAdminUnauthorized(t *testing.T) {
+	h := newHarness(t)
+	AdminRoutes(h.api, h.registry, h.auth)
+
+	w := h.doNoAuth(http.MethodGet, "/api/admin/registries/")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/cmd/api-gateway/routes/auth_routes_test.go
+++ b/cmd/api-gateway/routes/auth_routes_test.go
@@ -1,0 +1,101 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthRegister(t *testing.T) {
+	h := newHarness(t)
+	AuthRoutes(h.api, h.auth)
+
+	// New user.
+	w := h.do(http.MethodPost, "/api/auth/register",
+		[]byte(`{"username":"newuser","email":"new@example.com","password":"password12345"}`),
+		"application/json")
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Contains(t, w.Body.String(), "newuser")
+
+	// Duplicate username (harness already registered "routeuser").
+	w = h.do(http.MethodPost, "/api/auth/register",
+		[]byte(`{"username":"routeuser","email":"dup@example.com","password":"password12345"}`),
+		"application/json")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Malformed body.
+	w = h.do(http.MethodPost, "/api/auth/register", []byte("not-json"), "application/json")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAuthLogin(t *testing.T) {
+	h := newHarness(t)
+	AuthRoutes(h.api, h.auth)
+
+	// Valid creds (seeded by harness).
+	w := h.do(http.MethodPost, "/api/auth/login",
+		[]byte(`{"username":"routeuser","password":"testpassword123"}`), "application/json")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "token")
+
+	// Wrong password.
+	w = h.do(http.MethodPost, "/api/auth/login",
+		[]byte(`{"username":"routeuser","password":"wrong"}`), "application/json")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Malformed body.
+	w = h.do(http.MethodPost, "/api/auth/login", []byte("{"), "application/json")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAuthAPIKeyCreateListRevoke(t *testing.T) {
+	h := newHarness(t)
+	AuthRoutes(h.api, h.auth)
+
+	// Create.
+	w := h.do(http.MethodPost, "/api/auth/api-keys",
+		[]byte(`{"name":"ci-key","permissions":["read"]}`), "application/json")
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var created struct {
+		APIKey struct {
+			ID string `json:"id"`
+		} `json:"api_key"`
+		Key string `json:"key"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.NotEmpty(t, created.APIKey.ID)
+
+	// List.
+	w = h.do(http.MethodGet, "/api/auth/api-keys", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "ci-key")
+
+	// Revoke.
+	w = h.do(http.MethodDelete, "/api/auth/api-keys/"+created.APIKey.ID, nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestAuthAPIKey_BadInput(t *testing.T) {
+	h := newHarness(t)
+	AuthRoutes(h.api, h.auth)
+
+	// Missing required name.
+	w := h.do(http.MethodPost, "/api/auth/api-keys", []byte(`{}`), "application/json")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Revoke with non-UUID id.
+	w = h.do(http.MethodDelete, "/api/auth/api-keys/not-a-uuid", nil, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAuthProtected_Unauthorized(t *testing.T) {
+	h := newHarness(t)
+	AuthRoutes(h.api, h.auth)
+
+	w := h.doNoAuth(http.MethodGet, "/api/auth/api-keys")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/cmd/api-gateway/routes/cargo_routes_test.go
+++ b/cmd/api-gateway/routes/cargo_routes_test.go
@@ -1,0 +1,78 @@
+package routes
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCargoPublishSearchInfoDownloadYank(t *testing.T) {
+	h := newHarness(t)
+	CargoRoutes(h.api, h.registry, h.auth)
+
+	// Publish.
+	body, ct := multipartFile(t, "crate", "mycrate-1.0.0.crate", []byte("crate-bytes"))
+	w := h.do(http.MethodPut, "/api/cargo/api/v1/crates/new", body, ct)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Search.
+	w = h.do(http.MethodGet, "/api/cargo/api/v1/crates?q=mycrate", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "mycrate")
+
+	// Info.
+	w = h.do(http.MethodGet, "/api/cargo/api/v1/crates/mycrate", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "1.0.0")
+
+	// Download.
+	w = h.do(http.MethodGet, "/api/cargo/api/v1/crates/mycrate/1.0.0/download", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "crate-bytes", w.Body.String())
+
+	// Yank (delete).
+	w = h.do(http.MethodDelete, "/api/cargo/api/v1/crates/mycrate/1.0.0/yank", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCargoInfo_NotFound(t *testing.T) {
+	h := newHarness(t)
+	CargoRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/cargo/api/v1/crates/ghost", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCargoDownload_NotFound(t *testing.T) {
+	h := newHarness(t)
+	CargoRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/cargo/api/v1/crates/ghost/9.9.9/download", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCargoPublish_BadFilename(t *testing.T) {
+	h := newHarness(t)
+	CargoRoutes(h.api, h.registry, h.auth)
+
+	body, ct := multipartFile(t, "crate", "mycrate-1.0.0.zip", []byte("x"))
+	w := h.do(http.MethodPut, "/api/cargo/api/v1/crates/new", body, ct)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	body, ct = multipartFile(t, "crate", "noversion.crate", []byte("x"))
+	w = h.do(http.MethodPut, "/api/cargo/api/v1/crates/new", body, ct)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	body, ct = multipartFile(t, "wrong", "mycrate-1.0.0.crate", []byte("x"))
+	w = h.do(http.MethodPut, "/api/cargo/api/v1/crates/new", body, ct)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCargoUnauthorized(t *testing.T) {
+	h := newHarness(t)
+	CargoRoutes(h.api, h.registry, h.auth)
+
+	w := h.doNoAuth(http.MethodGet, "/api/cargo/api/v1/crates")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/cmd/api-gateway/routes/go_routes_test.go
+++ b/cmd/api-gateway/routes/go_routes_test.go
@@ -1,0 +1,87 @@
+package routes
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoUploadListLatestInfoModZipDelete(t *testing.T) {
+	h := newHarness(t)
+	GoRoutes(h.api, h.registry, h.auth)
+
+	// Upload module (raw body PUT).
+	w := h.do(http.MethodPut, "/api/go/mymod/@v/v1.0.0", []byte("zip-bytes"), "application/zip")
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	// Version list.
+	w = h.do(http.MethodGet, "/api/go/mymod/@v/list", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "v1.0.0")
+
+	// @latest.
+	w = h.do(http.MethodGet, "/api/go/mymod/@latest", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "v1.0.0")
+
+	// .info
+	w = h.do(http.MethodGet, "/api/go/mymod/@v/v1.0.0.info", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "v1.0.0")
+
+	// .mod
+	w = h.do(http.MethodGet, "/api/go/mymod/@v/v1.0.0.mod", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "module mymod")
+
+	// .zip
+	w = h.do(http.MethodGet, "/api/go/mymod/@v/v1.0.0.zip", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "zip-bytes", w.Body.String())
+
+	// Delete.
+	w = h.do(http.MethodDelete, "/api/go/mymod/@v/v1.0.0", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestGoVersionFile_UnsupportedType(t *testing.T) {
+	h := newHarness(t)
+	GoRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/go/mymod/@v/v1.0.0.txt", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGoLatest_NotFound(t *testing.T) {
+	h := newHarness(t)
+	GoRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/go/ghost/@latest", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGoInfo_NotFound(t *testing.T) {
+	h := newHarness(t)
+	GoRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/go/ghost/@v/v9.9.9.info", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGoUpload_InvalidVersion(t *testing.T) {
+	h := newHarness(t)
+	GoRoutes(h.api, h.registry, h.auth)
+
+	// Non-semver version fails registry validation -> 500 from handler.
+	w := h.do(http.MethodPut, "/api/go/mymod/@v/notsemver", []byte("x"), "application/zip")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestGoUnauthorized(t *testing.T) {
+	h := newHarness(t)
+	GoRoutes(h.api, h.registry, h.auth)
+
+	w := h.doNoAuth(http.MethodGet, "/api/go/mymod/@v/list")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/cmd/api-gateway/routes/harness_test.go
+++ b/cmd/api-gateway/routes/harness_test.go
@@ -1,0 +1,134 @@
+package routes
+
+import (
+	"bytes"
+	"context"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/lgulliver/lodestone/internal/auth"
+	"github.com/lgulliver/lodestone/internal/common"
+	"github.com/lgulliver/lodestone/internal/registry"
+	"github.com/lgulliver/lodestone/internal/storage"
+	"github.com/lgulliver/lodestone/pkg/config"
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+// testHarness wires real auth + registry services over sqlite and local storage so
+// route handlers can be exercised end-to-end through gin.
+type testHarness struct {
+	router   *gin.Engine
+	api      *gin.RouterGroup
+	registry *registry.Service
+	auth     *auth.Service
+	db       *common.Database
+	store    storage.BlobStorage
+	user     *types.User
+	token    string
+}
+
+// seedArtifact inserts an artifact row and stores its content so Download works.
+func (h *testHarness) seedArtifact(t *testing.T, reg, name, version string, content []byte, metadata types.JSONMap) {
+	t.Helper()
+	path := reg + "/" + name + "/" + version + "/" + name
+	require.NoError(t, h.store.Store(context.Background(), path, bytes.NewReader(content), "application/octet-stream"))
+	art := &types.Artifact{
+		Name: name, Version: version, Registry: reg,
+		StoragePath: path, Size: int64(len(content)),
+		PublishedBy: h.user.ID, Metadata: metadata,
+	}
+	require.NoError(t, h.db.Create(art).Error)
+	require.NoError(t, h.registry.Ownership.EstablishInitialOwnership(
+		context.Background(), reg, name, h.user.ID))
+}
+
+func newHarness(t *testing.T) *testHarness {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&types.User{}, &types.APIKey{}, &types.Artifact{},
+		&types.PackageOwnership{}, &types.RegistrySetting{},
+	))
+
+	for _, name := range []string{"npm", "nuget", "maven", "go", "helm", "oci", "opa", "cargo", "rubygems"} {
+		require.NoError(t, db.Create(&types.RegistrySetting{RegistryName: name, Enabled: true}).Error)
+	}
+
+	cdb := &common.Database{DB: db}
+
+	store, err := storage.NewLocalStorage(t.TempDir())
+	require.NoError(t, err)
+
+	regSvc := registry.NewService(cdb, store, nil)
+	authSvc := auth.NewService(cdb, nil, &config.AuthConfig{
+		JWTSecret:     "test-secret-key-for-routes",
+		JWTExpiration: time.Hour,
+		BCryptCost:    4,
+	})
+
+	ctx := context.Background()
+	user, err := authSvc.Register(ctx, &types.RegisterRequest{
+		Username: "routeuser", Email: "route@example.com", Password: "testpassword123",
+	})
+	require.NoError(t, err)
+
+	authToken, err := authSvc.Login(ctx, &types.LoginRequest{
+		Username: "routeuser", Password: "testpassword123",
+	})
+	require.NoError(t, err)
+
+	router := gin.New()
+	api := router.Group("/api")
+
+	return &testHarness{
+		router: router, api: api, registry: regSvc, auth: authSvc,
+		db: cdb, store: store, user: user, token: authToken.Token,
+	}
+}
+
+func (h *testHarness) do(method, path string, body []byte, contentType string) *httptest.ResponseRecorder {
+	var r *http.Request
+	if body != nil {
+		r = httptest.NewRequest(method, path, bytes.NewReader(body))
+	} else {
+		r = httptest.NewRequest(method, path, nil)
+	}
+	r.Header.Set("Authorization", "Bearer "+h.token)
+	if contentType != "" {
+		r.Header.Set("Content-Type", contentType)
+	}
+	w := httptest.NewRecorder()
+	h.router.ServeHTTP(w, r)
+	return w
+}
+
+func (h *testHarness) doNoAuth(method, path string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(method, path, nil)
+	w := httptest.NewRecorder()
+	h.router.ServeHTTP(w, r)
+	return w
+}
+
+// multipartFile builds a multipart body with a single file field.
+func multipartFile(t *testing.T, field, filename string, data []byte) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile(field, filename)
+	require.NoError(t, err)
+	_, err = fw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
+	return buf.Bytes(), mw.FormDataContentType()
+}

--- a/cmd/api-gateway/routes/helm_routes_test.go
+++ b/cmd/api-gateway/routes/helm_routes_test.go
@@ -1,0 +1,68 @@
+package routes
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHelmUploadIndexDownloadDelete(t *testing.T) {
+	h := newHarness(t)
+	HelmRoutes(h.api, h.registry, h.auth)
+
+	// Upload a chart.
+	body, ct := multipartFile(t, "chart", "mychart-1.0.0.tgz", []byte("chart-bytes"))
+	w := h.do(http.MethodPost, "/api/helm/api/charts", body, ct)
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	// Index lists it.
+	w = h.do(http.MethodGet, "/api/helm/index.yaml", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "mychart")
+
+	// Download it.
+	w = h.do(http.MethodGet, "/api/helm/mychart/1.0.0/mychart-1.0.0.tgz", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "chart-bytes", w.Body.String())
+
+	// Delete it.
+	w = h.do(http.MethodDelete, "/api/helm/api/charts/mychart/1.0.0", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestHelmUpload_BadFilename(t *testing.T) {
+	h := newHarness(t)
+	HelmRoutes(h.api, h.registry, h.auth)
+
+	// Not a .tgz.
+	body, ct := multipartFile(t, "chart", "mychart-1.0.0.zip", []byte("x"))
+	w := h.do(http.MethodPost, "/api/helm/api/charts", body, ct)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Missing version segment.
+	body, ct = multipartFile(t, "chart", "mychart.tgz", []byte("x"))
+	w = h.do(http.MethodPost, "/api/helm/api/charts", body, ct)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Wrong form field name.
+	body, ct = multipartFile(t, "wrong", "mychart-1.0.0.tgz", []byte("x"))
+	w = h.do(http.MethodPost, "/api/helm/api/charts", body, ct)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHelmDownload_NotFound(t *testing.T) {
+	h := newHarness(t)
+	HelmRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/helm/ghost/9.9.9/ghost-9.9.9.tgz", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHelmUnauthorized(t *testing.T) {
+	h := newHarness(t)
+	HelmRoutes(h.api, h.registry, h.auth)
+
+	w := h.doNoAuth(http.MethodGet, "/api/helm/index.yaml")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/cmd/api-gateway/routes/maven.go
+++ b/cmd/api-gateway/routes/maven.go
@@ -95,15 +95,11 @@ func handleMavenUpload(registryService *registry.Service) gin.HandlerFunc {
 			return
 		}
 
-		// Extract version and filename
+		// Parse the same way the read handlers do so uploads are fetchable:
+		// groupId = path[:-3] joined with '.', artifactId = path[-3], version = path[-2].
+		groupId := strings.Join(pathParts[:len(pathParts)-3], ".")
+		artifactID := pathParts[len(pathParts)-3]
 		version := pathParts[len(pathParts)-2]
-		filename := pathParts[len(pathParts)-1]
-
-		// Extract artifact ID from filename (remove version and extension)
-		artifactID := strings.Split(filename, "-")[0]
-
-		// Construct full artifact name (groupId:artifactId)
-		groupId := strings.Join(pathParts[:len(pathParts)-2], ".")
 		fullName := fmt.Sprintf("%s:%s", groupId, artifactID)
 
 		_, err := registryService.Upload(ctx, "maven", fullName, version, c.Request.Body, user.ID)

--- a/cmd/api-gateway/routes/maven_routes_test.go
+++ b/cmd/api-gateway/routes/maven_routes_test.go
@@ -35,14 +35,9 @@ func TestMavenDownloadHeadDelete(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, w.Code)
 }
 
-// BUG: upload builds the package name as join(parts[:len-2]) + ":" + artifactID,
-// which folds the artifactId into the groupId (-> "com.example.artifact:artifact").
-// Download/HEAD/Delete instead use join(parts[:len-3]) + ":" + parts[len-3]
-// (-> "com.example:artifact"). The two names never match, so an artifact uploaded
-// through the Maven PUT endpoint can never be fetched back through the GET endpoint.
-// Documented here until the path-parsing in handleMavenUpload is aligned with the
-// read handlers.
-func TestMavenUploadThenDownload_NameMismatchBug(t *testing.T) {
+// Upload and read handlers parse the Maven path identically, so an artifact
+// pushed through PUT is fetchable through GET.
+func TestMavenUploadThenDownload(t *testing.T) {
 	h := newHarness(t)
 	MavenRoutes(h.api, h.registry, h.auth)
 
@@ -51,7 +46,8 @@ func TestMavenUploadThenDownload_NameMismatchBug(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, w.Code)
 
 	w = h.do(http.MethodGet, "/api/maven/com/example/artifact/1.0.0/artifact-1.0.0.jar", nil, "")
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "jar-bytes", w.Body.String())
 }
 
 func TestMavenDownload_NotFound(t *testing.T) {

--- a/cmd/api-gateway/routes/maven_routes_test.go
+++ b/cmd/api-gateway/routes/maven_routes_test.go
@@ -1,0 +1,91 @@
+package routes
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMavenUpload_Created(t *testing.T) {
+	h := newHarness(t)
+	MavenRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodPut, "/api/maven/com/example/artifact/1.0.0/artifact-1.0.0.jar",
+		[]byte("jar-bytes"), "application/java-archive")
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
+// Download/HEAD/Delete resolve packageName as "<group>:<artifactId>" where
+// group = join(parts[:len-3]) and artifactId = parts[len-3]. We seed under that
+// exact name so the read path can find it.
+func TestMavenDownloadHeadDelete(t *testing.T) {
+	h := newHarness(t)
+	MavenRoutes(h.api, h.registry, h.auth)
+	h.seedArtifact(t, "maven", "com.example:artifact", "1.0.0", []byte("jar-bytes"), nil)
+
+	w := h.do(http.MethodGet, "/api/maven/com/example/artifact/1.0.0/artifact-1.0.0.jar", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "jar-bytes", w.Body.String())
+
+	w = h.do(http.MethodHead, "/api/maven/com/example/artifact/1.0.0/artifact-1.0.0.jar", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = h.do(http.MethodDelete, "/api/maven/com/example/artifact/1.0.0/artifact-1.0.0.jar", nil, "")
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+// BUG: upload builds the package name as join(parts[:len-2]) + ":" + artifactID,
+// which folds the artifactId into the groupId (-> "com.example.artifact:artifact").
+// Download/HEAD/Delete instead use join(parts[:len-3]) + ":" + parts[len-3]
+// (-> "com.example:artifact"). The two names never match, so an artifact uploaded
+// through the Maven PUT endpoint can never be fetched back through the GET endpoint.
+// Documented here until the path-parsing in handleMavenUpload is aligned with the
+// read handlers.
+func TestMavenUploadThenDownload_NameMismatchBug(t *testing.T) {
+	h := newHarness(t)
+	MavenRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodPut, "/api/maven/com/example/artifact/1.0.0/artifact-1.0.0.jar",
+		[]byte("jar-bytes"), "application/java-archive")
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	w = h.do(http.MethodGet, "/api/maven/com/example/artifact/1.0.0/artifact-1.0.0.jar", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestMavenDownload_NotFound(t *testing.T) {
+	h := newHarness(t)
+	MavenRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/maven/com/example/ghost/9.9.9/ghost-9.9.9.jar", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	w = h.do(http.MethodHead, "/api/maven/com/example/ghost/9.9.9/ghost-9.9.9.jar", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestMavenPathTooShort(t *testing.T) {
+	h := newHarness(t)
+	MavenRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/maven/a/b/c", nil, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	w = h.do(http.MethodPut, "/api/maven/a/b/c", []byte("x"), "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	w = h.do(http.MethodDelete, "/api/maven/a/b/c", nil, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	w = h.do(http.MethodHead, "/api/maven/a/b/c", nil, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestMavenUnauthorized(t *testing.T) {
+	h := newHarness(t)
+	MavenRoutes(h.api, h.registry, h.auth)
+
+	w := h.doNoAuth(http.MethodGet, "/api/maven/com/example/artifact/1.0.0/artifact-1.0.0.jar")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/cmd/api-gateway/routes/npm_routes_test.go
+++ b/cmd/api-gateway/routes/npm_routes_test.go
@@ -84,13 +84,13 @@ func TestNPMPublishInfoVersionDownloadSearchDelete(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "mypkg")
 
-	// BUG: handleNPMDelete calls registryService.Delete(..., version="") intending
-	// "delete all versions", but Service.Delete looks the artifact up with an exact
-	// `version = ?` match, so the empty version never resolves and delete always
-	// fails with 500. The npm unpublish endpoint is therefore non-functional.
-	// Documented here until Delete supports whole-package deletion.
+	// Unpublish whole package (empty version => delete all versions).
 	w = h.do(http.MethodDelete, "/api/npm/mypkg/-rev/1-0", nil, "")
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Package is gone.
+	w = h.do(http.MethodGet, "/api/npm/mypkg", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestNPMScopedPublishInfoDownloadDelete(t *testing.T) {
@@ -114,9 +114,8 @@ func TestNPMScopedPublishInfoDownloadDelete(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, tb, w.Body.Bytes())
 
-	// Same empty-version delete bug as the unscoped case (see TestNPMPublish...).
 	w = h.do(http.MethodDelete, "/api/npm/@myscope/mypkg/-rev/1-0", nil, "")
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestNPMInfoVersion_NotFound(t *testing.T) {

--- a/cmd/api-gateway/routes/npm_routes_test.go
+++ b/cmd/api-gateway/routes/npm_routes_test.go
@@ -1,0 +1,165 @@
+package routes
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// npmTarball builds a gzip+tar archive containing package/package.json.
+func npmTarball(t *testing.T, name, version string, extra map[string]interface{}) []byte {
+	t.Helper()
+	pkg := map[string]interface{}{"name": name, "version": version}
+	for k, v := range extra {
+		pkg[k] = v
+	}
+	data, err := json.Marshal(pkg)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "package/package.json", Mode: 0o644, Size: int64(len(data)),
+	}))
+	_, err = tw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	return buf.Bytes()
+}
+
+// npmPublishBody wraps a tarball in the npm publish JSON envelope.
+func npmPublishBody(t *testing.T, name, version string, tarball []byte) []byte {
+	t.Helper()
+	body := map[string]interface{}{
+		"_attachments": map[string]interface{}{
+			name + "-" + version + ".tgz": map[string]interface{}{
+				"data": base64.StdEncoding.EncodeToString(tarball),
+			},
+		},
+	}
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	return b
+}
+
+func TestNPMPublishInfoVersionDownloadSearchDelete(t *testing.T) {
+	h := newHarness(t)
+	NPMRoutes(h.api, h.registry, h.auth)
+
+	tb := npmTarball(t, "mypkg", "1.0.0", map[string]interface{}{
+		"description": "a package", "author": "Alice",
+	})
+
+	// Publish.
+	w := h.do(http.MethodPut, "/api/npm/mypkg", npmPublishBody(t, "mypkg", "1.0.0", tb), "application/json")
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Package info.
+	w = h.do(http.MethodGet, "/api/npm/mypkg", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "1.0.0")
+	assert.Contains(t, w.Body.String(), "dist-tags")
+
+	// Specific version.
+	w = h.do(http.MethodGet, "/api/npm/mypkg/1.0.0", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "mypkg@1.0.0")
+
+	// Tarball download.
+	w = h.do(http.MethodGet, "/api/npm/mypkg/-/mypkg-1.0.0.tgz", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, tb, w.Body.Bytes())
+
+	// Search.
+	w = h.do(http.MethodGet, "/api/npm/-/v1/search?text=mypkg", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "mypkg")
+
+	// BUG: handleNPMDelete calls registryService.Delete(..., version="") intending
+	// "delete all versions", but Service.Delete looks the artifact up with an exact
+	// `version = ?` match, so the empty version never resolves and delete always
+	// fails with 500. The npm unpublish endpoint is therefore non-functional.
+	// Documented here until Delete supports whole-package deletion.
+	w = h.do(http.MethodDelete, "/api/npm/mypkg/-rev/1-0", nil, "")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestNPMScopedPublishInfoDownloadDelete(t *testing.T) {
+	h := newHarness(t)
+	NPMRoutes(h.api, h.registry, h.auth)
+
+	tb := npmTarball(t, "@myscope/mypkg", "1.0.0", nil)
+
+	w := h.do(http.MethodPut, "/api/npm/@myscope/mypkg",
+		npmPublishBody(t, "@myscope/mypkg", "1.0.0", tb), "application/json")
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	w = h.do(http.MethodGet, "/api/npm/@myscope/mypkg", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "1.0.0")
+
+	w = h.do(http.MethodGet, "/api/npm/@myscope/mypkg/1.0.0", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = h.do(http.MethodGet, "/api/npm/@myscope/mypkg/-/mypkg-1.0.0.tgz", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, tb, w.Body.Bytes())
+
+	// Same empty-version delete bug as the unscoped case (see TestNPMPublish...).
+	w = h.do(http.MethodDelete, "/api/npm/@myscope/mypkg/-rev/1-0", nil, "")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestNPMInfoVersion_NotFound(t *testing.T) {
+	h := newHarness(t)
+	NPMRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/npm/ghost", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	w = h.do(http.MethodGet, "/api/npm/ghost/9.9.9", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	w = h.do(http.MethodGet, "/api/npm/ghost/-/ghost-9.9.9.tgz", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNPMPublish_BadInput(t *testing.T) {
+	h := newHarness(t)
+	NPMRoutes(h.api, h.registry, h.auth)
+
+	// Invalid JSON.
+	w := h.do(http.MethodPut, "/api/npm/mypkg", []byte("not-json"), "application/json")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Missing _attachments.
+	w = h.do(http.MethodPut, "/api/npm/mypkg", []byte(`{}`), "application/json")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Invalid base64 data.
+	bad := []byte(`{"_attachments":{"mypkg-1.0.0.tgz":{"data":"!!!not-base64!!!"}}}`)
+	w = h.do(http.MethodPut, "/api/npm/mypkg", bad, "application/json")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Name mismatch between path and package.json.
+	tb := npmTarball(t, "otherpkg", "1.0.0", nil)
+	w = h.do(http.MethodPut, "/api/npm/mypkg", npmPublishBody(t, "mypkg", "1.0.0", tb), "application/json")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNPMUnauthorized(t *testing.T) {
+	h := newHarness(t)
+	NPMRoutes(h.api, h.registry, h.auth)
+
+	w := h.doNoAuth(http.MethodGet, "/api/npm/mypkg")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/cmd/api-gateway/routes/nuget_routes_test.go
+++ b/cmd/api-gateway/routes/nuget_routes_test.go
@@ -1,0 +1,148 @@
+package routes
+
+import (
+	"archive/zip"
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nupkgBytes builds a minimal .nupkg/.snupkg zip containing an <id>.nuspec file.
+func nupkgBytes(t *testing.T, id, version string) []byte {
+	t.Helper()
+	nuspec := `<?xml version="1.0"?>
+<package><metadata><id>` + id + `</id><version>` + version + `</version>` +
+		`<authors>Alice</authors><description>a package</description></metadata></package>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	f, err := zw.Create(id + ".nuspec")
+	require.NoError(t, err)
+	_, err = f.Write([]byte(nuspec))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+// snupkgBytes builds a symbol package: nuspec + a .pdb entry (required by Validate).
+func snupkgBytes(t *testing.T, id, version string) []byte {
+	t.Helper()
+	nuspec := `<?xml version="1.0"?>
+<package><metadata><id>` + id + `</id><version>` + version + `</version>` +
+		`<authors>Alice</authors><description>a package</description></metadata></package>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	nf, err := zw.Create(id + ".nuspec")
+	require.NoError(t, err)
+	_, err = nf.Write([]byte(nuspec))
+	require.NoError(t, err)
+	pf, err := zw.Create("lib/" + id + ".pdb")
+	require.NoError(t, err)
+	_, err = pf.Write([]byte("fake-symbols"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func TestNuGetUploadVersionsDownloadSearchMetadataDelete(t *testing.T) {
+	h := newHarness(t)
+	NuGetRoutes(h.api, h.registry, h.auth)
+
+	// Upload (raw binary, NuGet CLI style).
+	w := h.do(http.MethodPut, "/api/nuget/v2/package",
+		nupkgBytes(t, "MyPkg", "1.0.0"), "application/octet-stream")
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Versions list.
+	w = h.do(http.MethodGet, "/api/nuget/v3-flatcontainer/MyPkg/index.json", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "1.0.0")
+
+	// Download.
+	w = h.do(http.MethodGet, "/api/nuget/v3-flatcontainer/MyPkg/1.0.0/MyPkg.1.0.0.nupkg", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Search.
+	w = h.do(http.MethodGet, "/api/nuget/v3/search?q=MyPkg", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "MyPkg")
+
+	// Registration metadata.
+	w = h.do(http.MethodGet, "/api/nuget/v3/registration/MyPkg/index.json", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "1.0.0")
+
+	// Delete (exact version).
+	w = h.do(http.MethodDelete, "/api/nuget/v2/package/MyPkg/1.0.0", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestNuGetServiceIndex(t *testing.T) {
+	h := newHarness(t)
+	NuGetRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/nuget/v3/index.json", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "PackagePublish")
+}
+
+func TestNuGetSymbolUploadDownload(t *testing.T) {
+	h := newHarness(t)
+	NuGetRoutes(h.api, h.registry, h.auth)
+
+	// Base package must exist before symbols.
+	w := h.do(http.MethodPut, "/api/nuget/v2/package",
+		nupkgBytes(t, "MyPkg", "1.0.0"), "application/octet-stream")
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Symbol upload (raw).
+	w = h.do(http.MethodPut, "/api/nuget/v2/symbolpackage",
+		snupkgBytes(t, "MyPkg", "1.0.0"), "application/octet-stream")
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Symbol download.
+	w = h.do(http.MethodGet, "/api/nuget/symbols/MyPkg/1.0.0/MyPkg.1.0.0.snupkg", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestNuGetSymbol_NoBasePackage(t *testing.T) {
+	h := newHarness(t)
+	NuGetRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodPut, "/api/nuget/v2/symbolpackage",
+		nupkgBytes(t, "Ghost", "1.0.0"), "application/octet-stream")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "base package")
+}
+
+func TestNuGetUpload_InvalidPackage(t *testing.T) {
+	h := newHarness(t)
+	NuGetRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodPut, "/api/nuget/v2/package",
+		[]byte("not-a-zip"), "application/octet-stream")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNuGetDownloadMetadata_NotFound(t *testing.T) {
+	h := newHarness(t)
+	NuGetRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/nuget/v3-flatcontainer/Ghost/9.9.9/Ghost.9.9.9.nupkg", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	w = h.do(http.MethodGet, "/api/nuget/v3/registration/Ghost/index.json", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNuGetUnauthorized(t *testing.T) {
+	h := newHarness(t)
+	NuGetRoutes(h.api, h.registry, h.auth)
+
+	w := h.doNoAuth(http.MethodGet, "/api/nuget/v3-flatcontainer/MyPkg/1.0.0/MyPkg.1.0.0.nupkg")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/cmd/api-gateway/routes/oci.go
+++ b/cmd/api-gateway/routes/oci.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -233,20 +234,45 @@ func handleOCIManifestPut(registryService *registry.Service) gin.HandlerFunc {
 			contentType = "application/vnd.docker.distribution.manifest.v2+json"
 		}
 
+		// Read the manifest body so we can both store it and record its size/digest.
+		manifestBytes, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read manifest body"})
+			return
+		}
+
 		// Store manifest using enhanced method
-		digest, err := ociRegistry.PutManifest(c.Request.Context(), name, reference, c.Request.Body, contentType)
+		digest, err := ociRegistry.PutManifest(c.Request.Context(), name, reference, bytes.NewReader(manifestBytes), contentType)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to store manifest: %v", err)})
 			return
 		}
 
-		// Create artifact record in database
+		// Record the manifest as an artifact so it surfaces in tags/list and
+		// _catalog. The OCI registry's Upload path rejects empty content, so the
+		// record is created directly here against the manifest's actual bytes.
 		ctx := context.WithValue(c.Request.Context(), registryKey, "oci")
 		ctx = context.WithValue(ctx, userIDKey, user.ID)
 
-		_, err = registryService.Upload(ctx, "oci", name, reference, strings.NewReader(""), user.ID)
-		if err != nil {
+		artifact := &types.Artifact{
+			Name:        name,
+			Version:     reference,
+			Registry:    "oci",
+			Size:        int64(len(manifestBytes)),
+			SHA256:      strings.TrimPrefix(digest, "sha256:"),
+			StoragePath: fmt.Sprintf("oci/%s/manifests/%s", name, reference),
+			PublishedBy: user.ID,
+			IsPublic:    false,
+			ContentType: contentType,
+		}
+		if err := registryService.DB.Where(
+			"registry = ? AND name = ? AND version = ?", "oci", name, reference,
+		).Assign(artifact).FirstOrCreate(artifact).Error; err != nil {
 			log.Warn().Err(err).Str("repository", name).Str("reference", reference).Msg("Failed to create artifact record")
+		}
+
+		if err := registryService.Ownership.EstablishInitialOwnership(ctx, "oci", name, user.ID); err != nil {
+			log.Warn().Err(err).Str("repository", name).Msg("Failed to establish ownership")
 		}
 
 		c.Header("Location", fmt.Sprintf("/v2/%s/manifests/%s", name, reference))
@@ -812,6 +838,14 @@ func handleOCIBlobUploadComplete(registryService *registry.Service) gin.HandlerF
 		if err := registryService.DB.Create(artifact).Error; err != nil {
 			log.Error().Err(err).Str("digest", digest).Msg("Failed to save blob artifact to database")
 			// Don't return error as the blob is already stored successfully
+		}
+
+		// Record the uploader as the repository owner so they can later manage
+		// (e.g. delete) what they pushed. No-op if ownership already exists.
+		ctx := context.WithValue(c.Request.Context(), registryKey, "oci")
+		ctx = context.WithValue(ctx, userIDKey, user.ID)
+		if err := registryService.Ownership.EstablishInitialOwnership(ctx, "oci", name, user.ID); err != nil {
+			log.Warn().Err(err).Str("repository", name).Msg("Failed to establish ownership")
 		}
 
 		c.Header("Location", fmt.Sprintf("/v2/%s/blobs/%s", name, digest))

--- a/cmd/api-gateway/routes/oci_routes_test.go
+++ b/cmd/api-gateway/routes/oci_routes_test.go
@@ -1,0 +1,272 @@
+package routes
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blobDigest returns the sha256: digest string for the given bytes.
+func blobDigest(b []byte) string {
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// dockerManifest is a minimal but valid v2 manifest JSON. PutManifest only
+// requires the body to parse as JSON for the docker/oci content types.
+func dockerManifest(t *testing.T) []byte {
+	t.Helper()
+	m := map[string]interface{}{
+		"schemaVersion": 2,
+		"mediaType":     "application/vnd.docker.distribution.manifest.v2+json",
+		"config":        map[string]interface{}{"mediaType": "application/vnd.docker.container.image.v1+json", "size": 0, "digest": "sha256:" + hex.EncodeToString(make([]byte, 32))},
+		"layers":        []interface{}{},
+	}
+	b, err := json.Marshal(m)
+	require.NoError(t, err)
+	return b
+}
+
+const dockerManifestType = "application/vnd.docker.distribution.manifest.v2+json"
+
+func TestOCIBlobPushPullDelete(t *testing.T) {
+	h := newHarness(t)
+	OCIRoutes(h.api, h.registry, h.auth)
+
+	blob := []byte("hello-layer-bytes")
+	digest := blobDigest(blob)
+
+	// Start upload session.
+	w := h.do(http.MethodPost, "/api/v2/myrepo/blobs/uploads/", nil, "")
+	require.Equal(t, http.StatusAccepted, w.Code)
+	uuid := w.Header().Get("Docker-Upload-UUID")
+	require.NotEmpty(t, uuid)
+
+	// Status check.
+	w = h.do(http.MethodGet, "/api/v2/myrepo/blobs/uploads/"+uuid, nil, "")
+	assert.Equal(t, http.StatusNoContent, w.Code)
+
+	// Push the full blob as a chunk.
+	w = h.do(http.MethodPatch, "/api/v2/myrepo/blobs/uploads/"+uuid, blob, "application/octet-stream")
+	require.Equal(t, http.StatusAccepted, w.Code)
+
+	// Complete with digest verification (no extra body).
+	w = h.do(http.MethodPut, "/api/v2/myrepo/blobs/uploads/"+uuid+"?digest="+digest, nil, "")
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Blob exists (HEAD) and downloads (GET).
+	w = h.do(http.MethodHead, "/api/v2/myrepo/blobs/"+digest, nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = h.do(http.MethodGet, "/api/v2/myrepo/blobs/"+digest, nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, blob, w.Body.Bytes())
+
+	// BUG: the blob upload flow stores the artifact (DB.Create) but never calls
+	// EstablishInitialOwnership, so no owner row exists for oci/myrepo. The delete
+	// handler's CanUserDelete check therefore returns false and rejects the
+	// uploader's own delete with 403 — OCI blobs are effectively undeletable.
+	// Documented here until OCI push establishes ownership.
+	w = h.do(http.MethodDelete, "/api/v2/myrepo/blobs/"+digest, nil, "")
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestOCIManifestPushPullTagsCatalogDelete(t *testing.T) {
+	h := newHarness(t)
+	OCIRoutes(h.api, h.registry, h.auth)
+
+	mf := dockerManifest(t)
+
+	// Push manifest under tag "latest".
+	w := h.do(http.MethodPut, "/api/v2/myrepo/manifests/latest", mf, dockerManifestType)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Pull manifest (GET) and HEAD.
+	w = h.do(http.MethodGet, "/api/v2/myrepo/manifests/latest", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "schemaVersion")
+
+	w = h.do(http.MethodHead, "/api/v2/myrepo/manifests/latest", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// BUG: handleOCIManifestPut creates the DB artifact record by calling
+	// registryService.Upload with an EMPTY body. The OCI registry's Validate
+	// rejects empty content ("empty blob content"), so the record is never
+	// created. tags/list and _catalog are sourced from that DB record, so a
+	// manifest pushed through the normal flow never appears in either listing.
+	// Both endpoints return 200 with empty results. Documented until manifest
+	// PUT records the artifact without failing validation.
+	w = h.do(http.MethodGet, "/api/v2/myrepo/tags/list", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"tags":[]`)
+
+	w = h.do(http.MethodGet, "/api/v2/_catalog", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"repositories":[]`)
+
+	// BUG: same missing-ownership issue as blobs — the manifest push never
+	// establishes ownership, so CanUserDelete rejects the uploader's delete
+	// with 403 instead of 202.
+	w = h.do(http.MethodDelete, "/api/v2/myrepo/manifests/latest", nil, "")
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestOCIBlobUploadCancel(t *testing.T) {
+	h := newHarness(t)
+	OCIRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodPost, "/api/v2/myrepo/blobs/uploads/", nil, "")
+	require.Equal(t, http.StatusAccepted, w.Code)
+	uuid := w.Header().Get("Docker-Upload-UUID")
+	require.NotEmpty(t, uuid)
+
+	w = h.do(http.MethodDelete, "/api/v2/myrepo/blobs/uploads/"+uuid, nil, "")
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestOCIBlobComplete_MissingDigest(t *testing.T) {
+	h := newHarness(t)
+	OCIRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodPost, "/api/v2/myrepo/blobs/uploads/", nil, "")
+	require.Equal(t, http.StatusAccepted, w.Code)
+	uuid := w.Header().Get("Docker-Upload-UUID")
+
+	// Complete without digest query param.
+	w = h.do(http.MethodPut, "/api/v2/myrepo/blobs/uploads/"+uuid, nil, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestOCIBlobGet_BadDigest(t *testing.T) {
+	h := newHarness(t)
+	OCIRoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/v2/myrepo/blobs/notadigest", nil, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestOCIBlobAndManifest_NotFound(t *testing.T) {
+	h := newHarness(t)
+	OCIRoutes(h.api, h.registry, h.auth)
+
+	missing := blobDigest([]byte("nope"))
+	w := h.do(http.MethodGet, "/api/v2/myrepo/blobs/"+missing, nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	w = h.do(http.MethodGet, "/api/v2/myrepo/manifests/ghost", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestOCIUnauthorized(t *testing.T) {
+	h := newHarness(t)
+	OCIRoutes(h.api, h.registry, h.auth)
+
+	w := h.doNoAuth(http.MethodGet, "/api/v2/myrepo/tags/list")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestOCIDockerTokenRequiresBasicAuth(t *testing.T) {
+	h := newHarness(t)
+	OCIRoutes(h.api, h.registry, h.auth)
+
+	w := h.doNoAuth(http.MethodGet, "/api/v2/token")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	w = h.doNoAuth(http.MethodGet, "/api/v2/auth")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// ociBasic issues a request against the root-mounted catch-all router with HTTP
+// Basic Auth credentials (used by the Docker login flow).
+func (h *testHarness) ociBasic(method, path, user, pass string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(method, path, nil)
+	r.SetBasicAuth(user, pass)
+	w := httptest.NewRecorder()
+	h.router.ServeHTTP(w, r)
+	return w
+}
+
+// TestOCICatchAllFlow exercises the root-level catch-all router (OCIRootRoutes),
+// which Docker CLIs hit at /v2/* with multi-segment repository names.
+func TestOCICatchAllFlow(t *testing.T) {
+	h := newHarness(t)
+	OCIRootRoutes(h.router, h.registry, h.auth)
+
+	repo := "library/myapp"
+	blob := []byte("catchall-layer")
+	digest := blobDigest(blob)
+
+	// Base endpoint.
+	w := h.do(http.MethodGet, "/v2/", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Lodestone OCI Registry")
+
+	// Blob upload session.
+	w = h.do(http.MethodPost, "/v2/"+repo+"/blobs/uploads/", nil, "")
+	require.Equal(t, http.StatusAccepted, w.Code)
+	uuid := w.Header().Get("Docker-Upload-UUID")
+	require.NotEmpty(t, uuid)
+
+	// Status, chunk, complete.
+	w = h.do(http.MethodGet, "/v2/"+repo+"/blobs/uploads/"+uuid, nil, "")
+	assert.Equal(t, http.StatusNoContent, w.Code)
+
+	w = h.do(http.MethodPatch, "/v2/"+repo+"/blobs/uploads/"+uuid, blob, "application/octet-stream")
+	require.Equal(t, http.StatusAccepted, w.Code)
+
+	w = h.do(http.MethodPut, "/v2/"+repo+"/blobs/uploads/"+uuid+"?digest="+digest, nil, "")
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Blob HEAD + GET.
+	w = h.do(http.MethodHead, "/v2/"+repo+"/blobs/"+digest, nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = h.do(http.MethodGet, "/v2/"+repo+"/blobs/"+digest, nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, blob, w.Body.Bytes())
+
+	// Manifest push + pull through the catch-all.
+	w = h.do(http.MethodPut, "/v2/"+repo+"/manifests/latest", dockerManifest(t), dockerManifestType)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	w = h.do(http.MethodGet, "/v2/"+repo+"/manifests/latest", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Tags + catalog endpoints respond (empty, per the documented manifest-record bug).
+	w = h.do(http.MethodGet, "/v2/"+repo+"/tags/list", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w = h.do(http.MethodGet, "/v2/_catalog", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Unknown sub-path → 404.
+	w = h.do(http.MethodGet, "/v2/"+repo+"/bogus", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestOCICatchAllDockerAuth(t *testing.T) {
+	h := newHarness(t)
+	OCIRootRoutes(h.router, h.registry, h.auth)
+
+	// No credentials → challenge.
+	w := h.do(http.MethodGet, "/v2/auth", nil, "")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	w = h.do(http.MethodGet, "/v2/token", nil, "")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Valid username/password (login fallback) issues a bearer token.
+	w = h.ociBasic(http.MethodGet, "/v2/auth", "routeuser", "testpassword123")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "token")
+
+	// Wrong password → 401.
+	w = h.ociBasic(http.MethodGet, "/v2/auth", "routeuser", "wrong")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/cmd/api-gateway/routes/oci_routes_test.go
+++ b/cmd/api-gateway/routes/oci_routes_test.go
@@ -68,13 +68,9 @@ func TestOCIBlobPushPullDelete(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, blob, w.Body.Bytes())
 
-	// BUG: the blob upload flow stores the artifact (DB.Create) but never calls
-	// EstablishInitialOwnership, so no owner row exists for oci/myrepo. The delete
-	// handler's CanUserDelete check therefore returns false and rejects the
-	// uploader's own delete with 403 — OCI blobs are effectively undeletable.
-	// Documented here until OCI push establishes ownership.
+	// Uploader is recorded as owner on push, so they can delete the blob.
 	w = h.do(http.MethodDelete, "/api/v2/myrepo/blobs/"+digest, nil, "")
-	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, http.StatusAccepted, w.Code)
 }
 
 func TestOCIManifestPushPullTagsCatalogDelete(t *testing.T) {
@@ -95,26 +91,18 @@ func TestOCIManifestPushPullTagsCatalogDelete(t *testing.T) {
 	w = h.do(http.MethodHead, "/api/v2/myrepo/manifests/latest", nil, "")
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	// BUG: handleOCIManifestPut creates the DB artifact record by calling
-	// registryService.Upload with an EMPTY body. The OCI registry's Validate
-	// rejects empty content ("empty blob content"), so the record is never
-	// created. tags/list and _catalog are sourced from that DB record, so a
-	// manifest pushed through the normal flow never appears in either listing.
-	// Both endpoints return 200 with empty results. Documented until manifest
-	// PUT records the artifact without failing validation.
+	// Pushed manifest is recorded, so it appears in tags/list and _catalog.
 	w = h.do(http.MethodGet, "/api/v2/myrepo/tags/list", nil, "")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), `"tags":[]`)
+	assert.Contains(t, w.Body.String(), "latest")
 
 	w = h.do(http.MethodGet, "/api/v2/_catalog", nil, "")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), `"repositories":[]`)
+	assert.Contains(t, w.Body.String(), "myrepo")
 
-	// BUG: same missing-ownership issue as blobs — the manifest push never
-	// establishes ownership, so CanUserDelete rejects the uploader's delete
-	// with 403 instead of 202.
+	// Uploader is owner, so manifest delete is accepted.
 	w = h.do(http.MethodDelete, "/api/v2/myrepo/manifests/latest", nil, "")
-	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, http.StatusAccepted, w.Code)
 }
 
 func TestOCIBlobUploadCancel(t *testing.T) {

--- a/cmd/api-gateway/routes/opa_routes_test.go
+++ b/cmd/api-gateway/routes/opa_routes_test.go
@@ -1,0 +1,70 @@
+package routes
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOPAUploadListDownloadDelete(t *testing.T) {
+	h := newHarness(t)
+	OPARoutes(h.api, h.registry, h.auth)
+
+	// Upload with explicit version.
+	w := h.do(http.MethodPut, "/api/opa/bundles/mybundle/v1.0.0", []byte("rego-bytes"), "application/gzip")
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	// List.
+	w = h.do(http.MethodGet, "/api/opa/bundles", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "mybundle")
+
+	// Download latest by name.
+	w = h.do(http.MethodGet, "/api/opa/bundles/mybundle", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "rego-bytes", w.Body.String())
+
+	// Download specific version.
+	w = h.do(http.MethodGet, "/api/opa/bundles/mybundle/v1.0.0", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Delete.
+	w = h.do(http.MethodDelete, "/api/opa/bundles/mybundle/v1.0.0", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestOPAUpload_DefaultVersionFromHeader(t *testing.T) {
+	h := newHarness(t)
+	OPARoutes(h.api, h.registry, h.auth)
+
+	// PUT without version path, version supplied via header.
+	r := httptest.NewRequest(http.MethodPut, "/api/opa/bundles/headerbundle", bytes.NewReader([]byte("rego")))
+	r.Header.Set("Authorization", "Bearer "+h.token)
+	r.Header.Set("X-Bundle-Version", "2.0.0")
+	w := httptest.NewRecorder()
+	h.router.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Contains(t, w.Body.String(), "v2.0.0")
+}
+
+func TestOPADownload_NotFound(t *testing.T) {
+	h := newHarness(t)
+	OPARoutes(h.api, h.registry, h.auth)
+
+	w := h.do(http.MethodGet, "/api/opa/bundles/ghost", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	w = h.do(http.MethodGet, "/api/opa/bundles/ghost/v9.9.9", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestOPAUnauthorized(t *testing.T) {
+	h := newHarness(t)
+	OPARoutes(h.api, h.registry, h.auth)
+
+	w := h.doNoAuth(http.MethodGet, "/api/opa/bundles")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/cmd/api-gateway/routes/ownership_routes_test.go
+++ b/cmd/api-gateway/routes/ownership_routes_test.go
@@ -42,13 +42,9 @@ func TestOwnershipGetAddRemove(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-// BUG: RemoveOwner's "last owner" guard counts only rows with role=owner and
-// rejects the removal whenever that count is <= 1 — without checking the target's
-// role. So removing a *maintainer* or *contributor* from a package that has a
-// single owner fails with "cannot remove the last owner of a package", even
-// though no owner is being removed. Documented here until the guard checks the
-// target's role before blocking.
-func TestOwnershipRemoveMaintainer_BlockedByLastOwnerGuardBug(t *testing.T) {
+// Removing a maintainer from a single-owner package must succeed: the last-owner
+// guard only applies when the target being removed is itself an owner.
+func TestOwnershipRemoveMaintainer_Allowed(t *testing.T) {
 	h := newHarness(t)
 	PackageOwnershipRoutes(h.api, h.registry, h.auth)
 	h.seedArtifact(t, "npm", "mypkg", "1.0.0", []byte("x"), nil)
@@ -59,6 +55,16 @@ func TestOwnershipRemoveMaintainer_BlockedByLastOwnerGuardBug(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, w.Code)
 
 	w = h.do(http.MethodDelete, "/api/packages/npm/mypkg/owners/"+second.ID.String(), nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// The last *owner* still cannot be removed.
+func TestOwnershipRemoveLastOwner_Blocked(t *testing.T) {
+	h := newHarness(t)
+	PackageOwnershipRoutes(h.api, h.registry, h.auth)
+	h.seedArtifact(t, "npm", "mypkg", "1.0.0", []byte("x"), nil)
+
+	w := h.do(http.MethodDelete, "/api/packages/npm/mypkg/owners/"+h.user.ID.String(), nil, "")
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, w.Body.String(), "cannot remove the last owner")
 }

--- a/cmd/api-gateway/routes/ownership_routes_test.go
+++ b/cmd/api-gateway/routes/ownership_routes_test.go
@@ -1,0 +1,106 @@
+package routes
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+func registerUser(t *testing.T, h *testHarness, username, email string) *types.User {
+	t.Helper()
+	u, err := h.auth.Register(context.Background(), &types.RegisterRequest{
+		Username: username, Email: email, Password: "testpassword123",
+	})
+	require.NoError(t, err)
+	return u
+}
+
+func TestOwnershipGetAddRemove(t *testing.T) {
+	h := newHarness(t)
+	PackageOwnershipRoutes(h.api, h.registry, h.auth)
+	// seedArtifact makes h.user the initial owner of npm/mypkg.
+	h.seedArtifact(t, "npm", "mypkg", "1.0.0", []byte("x"), nil)
+	second := registerUser(t, h, "second", "second@example.com")
+
+	// Get owners.
+	w := h.do(http.MethodGet, "/api/packages/npm/mypkg/owners", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), h.user.ID.String())
+
+	// Add second user as owner (so there are 2 owners and removal is permitted).
+	w = h.do(http.MethodPost, "/api/packages/npm/mypkg/owners",
+		[]byte(`{"user_id":"`+second.ID.String()+`","role":"owner"}`), "application/json")
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	// Remove second user.
+	w = h.do(http.MethodDelete, "/api/packages/npm/mypkg/owners/"+second.ID.String(), nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// BUG: RemoveOwner's "last owner" guard counts only rows with role=owner and
+// rejects the removal whenever that count is <= 1 — without checking the target's
+// role. So removing a *maintainer* or *contributor* from a package that has a
+// single owner fails with "cannot remove the last owner of a package", even
+// though no owner is being removed. Documented here until the guard checks the
+// target's role before blocking.
+func TestOwnershipRemoveMaintainer_BlockedByLastOwnerGuardBug(t *testing.T) {
+	h := newHarness(t)
+	PackageOwnershipRoutes(h.api, h.registry, h.auth)
+	h.seedArtifact(t, "npm", "mypkg", "1.0.0", []byte("x"), nil)
+	second := registerUser(t, h, "second", "second@example.com")
+
+	w := h.do(http.MethodPost, "/api/packages/npm/mypkg/owners",
+		[]byte(`{"user_id":"`+second.ID.String()+`","role":"maintainer"}`), "application/json")
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	w = h.do(http.MethodDelete, "/api/packages/npm/mypkg/owners/"+second.ID.String(), nil, "")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "cannot remove the last owner")
+}
+
+func TestOwnershipAdd_BadInput(t *testing.T) {
+	h := newHarness(t)
+	PackageOwnershipRoutes(h.api, h.registry, h.auth)
+	h.seedArtifact(t, "npm", "mypkg", "1.0.0", []byte("x"), nil)
+	second := registerUser(t, h, "second", "second@example.com")
+
+	// Malformed body.
+	w := h.do(http.MethodPost, "/api/packages/npm/mypkg/owners", []byte("{"), "application/json")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Invalid role.
+	w = h.do(http.MethodPost, "/api/packages/npm/mypkg/owners",
+		[]byte(`{"user_id":"`+second.ID.String()+`","role":"god"}`), "application/json")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Invalid target user id on remove.
+	w = h.do(http.MethodDelete, "/api/packages/npm/mypkg/owners/not-a-uuid", nil, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestOwnershipMyPackages(t *testing.T) {
+	h := newHarness(t)
+	PackageOwnershipRoutes(h.api, h.registry, h.auth)
+	h.seedArtifact(t, "npm", "mypkg", "1.0.0", []byte("x"), nil)
+
+	w := h.do(http.MethodGet, "/api/packages/my-packages", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "mypkg")
+
+	// Pagination params accepted.
+	w = h.do(http.MethodGet, "/api/packages/my-packages?page=1&per_page=10", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestOwnershipUnauthorized(t *testing.T) {
+	h := newHarness(t)
+	PackageOwnershipRoutes(h.api, h.registry, h.auth)
+
+	w := h.doNoAuth(http.MethodGet, "/api/packages/my-packages")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/cmd/api-gateway/routes/rubygems.go
+++ b/cmd/api-gateway/routes/rubygems.go
@@ -20,8 +20,8 @@ func RubyGemsRoutes(api *gin.RouterGroup, registryService *registry.Service, aut
 
 	// RubyGems API - requires authentication
 	gems.GET("/api/v1/gems", middleware.AuthMiddleware(authService), handleGemsSearch(registryService))
-	gems.GET("/api/v1/gems/:name.json", middleware.AuthMiddleware(authService), handleGemInfo(registryService))
-	gems.GET("/api/v1/versions/:name.json", middleware.AuthMiddleware(authService), handleGemVersions(registryService))
+	gems.GET("/api/v1/gems/:name", middleware.AuthMiddleware(authService), handleGemInfo(registryService))
+	gems.GET("/api/v1/versions/:name", middleware.AuthMiddleware(authService), handleGemVersions(registryService))
 	gems.GET("/gems/:filename", middleware.AuthMiddleware(authService), handleGemDownload(registryService))
 
 	// Gem push (requires authentication)
@@ -82,7 +82,7 @@ func handleGemsSearch(registryService *registry.Service) gin.HandlerFunc {
 
 func handleGemInfo(registryService *registry.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		gemName := c.Param("name")
+		gemName := strings.TrimSuffix(c.Param("name"), ".json")
 		if gemName == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "gem name required"})
 			return
@@ -132,7 +132,7 @@ func handleGemInfo(registryService *registry.Service) gin.HandlerFunc {
 
 func handleGemVersions(registryService *registry.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		gemName := c.Param("name")
+		gemName := strings.TrimSuffix(c.Param("name"), ".json")
 		if gemName == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "gem name required"})
 			return

--- a/cmd/api-gateway/routes/rubygems_routes_test.go
+++ b/cmd/api-gateway/routes/rubygems_routes_test.go
@@ -1,0 +1,91 @@
+package routes
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+func TestGemsSearchInfoVersionsDownload(t *testing.T) {
+	h := newHarness(t)
+	RubyGemsRoutes(h.api, h.registry, h.auth)
+	h.seedArtifact(t, "rubygems", "mygem", "1.0.0", []byte("gem-bytes"),
+		types.JSONMap{"description": "a gem", "author": "Alice"})
+
+	w := h.do(http.MethodGet, "/api/gems/api/v1/gems?query=mygem", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "mygem")
+
+	w = h.do(http.MethodGet, "/api/gems/gems/mygem-1.0.0.gem", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "gem-bytes", w.Body.String())
+}
+
+// BUG: the routes use gin params ":name.json"/":filename" where ":name.json"
+// captures the param under key "name.json", so c.Param("name") is always empty
+// and handleGemInfo/handleGemVersions can never see a gem name. Both endpoints
+// therefore always return 400 regardless of input. Documented here until the
+// route definitions are fixed to use a proper param + ".json" handling.
+func TestGemInfoVersions_BrokenParamAlways400(t *testing.T) {
+	h := newHarness(t)
+	RubyGemsRoutes(h.api, h.registry, h.auth)
+	h.seedArtifact(t, "rubygems", "mygem", "1.0.0", []byte("x"), nil)
+
+	w := h.do(http.MethodGet, "/api/gems/api/v1/gems/mygem.json", nil, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	w = h.do(http.MethodGet, "/api/gems/api/v1/versions/mygem.json", nil, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGemDownload_BadFilename(t *testing.T) {
+	h := newHarness(t)
+	RubyGemsRoutes(h.api, h.registry, h.auth)
+
+	// Not a .gem.
+	w := h.do(http.MethodGet, "/api/gems/gems/bad.zip", nil, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// .gem but no version separator.
+	w = h.do(http.MethodGet, "/api/gems/gems/noversion.gem", nil, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGemYank(t *testing.T) {
+	h := newHarness(t)
+	RubyGemsRoutes(h.api, h.registry, h.auth)
+	h.seedArtifact(t, "rubygems", "yankme", "2.0.0", []byte("x"), nil)
+
+	w := h.do(http.MethodDelete, "/api/gems/api/v1/gems/yank?gem_name=yankme&version=2.0.0", nil, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Missing params.
+	w = h.do(http.MethodDelete, "/api/gems/api/v1/gems/yank", nil, "")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGemPush_BadFilename(t *testing.T) {
+	h := newHarness(t)
+	RubyGemsRoutes(h.api, h.registry, h.auth)
+
+	body, ct := multipartFile(t, "gem", "mygem-1.0.0.zip", []byte("x"))
+	w := h.do(http.MethodPost, "/api/gems/api/v1/gems", body, ct)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	body, ct = multipartFile(t, "gem", "noversion.gem", []byte("x"))
+	w = h.do(http.MethodPost, "/api/gems/api/v1/gems", body, ct)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGemSpecsEndpoints(t *testing.T) {
+	h := newHarness(t)
+	RubyGemsRoutes(h.api, h.registry, h.auth)
+
+	for _, p := range []string{"/api/gems/specs.4.8.gz", "/api/gems/latest_specs.4.8.gz", "/api/gems/prerelease_specs.4.8.gz"} {
+		w := h.do(http.MethodGet, p, nil, "")
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+}

--- a/cmd/api-gateway/routes/rubygems_routes_test.go
+++ b/cmd/api-gateway/routes/rubygems_routes_test.go
@@ -24,21 +24,24 @@ func TestGemsSearchInfoVersionsDownload(t *testing.T) {
 	assert.Equal(t, "gem-bytes", w.Body.String())
 }
 
-// BUG: the routes use gin params ":name.json"/":filename" where ":name.json"
-// captures the param under key "name.json", so c.Param("name") is always empty
-// and handleGemInfo/handleGemVersions can never see a gem name. Both endpoints
-// therefore always return 400 regardless of input. Documented here until the
-// route definitions are fixed to use a proper param + ".json" handling.
-func TestGemInfoVersions_BrokenParamAlways400(t *testing.T) {
+func TestGemInfoVersions(t *testing.T) {
 	h := newHarness(t)
 	RubyGemsRoutes(h.api, h.registry, h.auth)
-	h.seedArtifact(t, "rubygems", "mygem", "1.0.0", []byte("x"), nil)
+	h.seedArtifact(t, "rubygems", "mygem", "1.0.0", []byte("x"),
+		types.JSONMap{"description": "a gem", "author": "Alice"})
 
 	w := h.do(http.MethodGet, "/api/gems/api/v1/gems/mygem.json", nil, "")
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "mygem")
+	assert.Contains(t, w.Body.String(), "1.0.0")
 
 	w = h.do(http.MethodGet, "/api/gems/api/v1/versions/mygem.json", nil, "")
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "1.0.0")
+
+	// Unknown gem → 404.
+	w = h.do(http.MethodGet, "/api/gems/api/v1/gems/ghost.json", nil, "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestGemDownload_BadFilename(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -117,8 +117,8 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	golang.org/x/arch v0.27.0 // indirect
-	golang.org/x/net v0.54.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
@@ -276,8 +276,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=

--- a/internal/auth/service_extra_test.go
+++ b/internal/auth/service_extra_test.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+	"github.com/lgulliver/lodestone/pkg/utils"
+)
+
+func TestValidateToken_UserNotFound(t *testing.T) {
+	service, _ := setupTestService(t)
+	ctx := context.Background()
+
+	// Valid JWT for a user that does not exist in the DB.
+	token, err := utils.GenerateJWT(uuid.New(), service.config.JWTSecret, time.Hour)
+	require.NoError(t, err)
+
+	user, err := service.ValidateToken(ctx, token)
+	assert.Error(t, err)
+	assert.Nil(t, user)
+	assert.Contains(t, err.Error(), "user not found")
+}
+
+func TestValidateOCIToken_Malformed(t *testing.T) {
+	service, _ := setupTestService(t)
+	_, _, err := service.ValidateOCIToken(context.Background(), "not.a.token")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid OCI token")
+}
+
+func TestAuthorizeOCITokenScope_Branches(t *testing.T) {
+	service, _ := setupTestService(t)
+
+	// nil claims
+	assert.Error(t, service.AuthorizeOCITokenScope(nil, "repo", "pull"))
+
+	// empty repository/action short-circuits to allow
+	assert.NoError(t, service.AuthorizeOCITokenScope(&OCITokenClaims{}, "", "pull"))
+	assert.NoError(t, service.AuthorizeOCITokenScope(&OCITokenClaims{}, "repo", ""))
+
+	// access derived from Scope strings when Access empty
+	scopeClaims := &OCITokenClaims{Scope: []string{"repository:team/app:pull,push"}}
+	assert.NoError(t, service.AuthorizeOCITokenScope(scopeClaims, "team/app", "push"))
+
+	// wildcard name + wildcard action
+	wild := &OCITokenClaims{Access: []OCIAccessEntry{{Type: "repository", Name: "*", Actions: []string{"*"}}}}
+	assert.NoError(t, service.AuthorizeOCITokenScope(wild, "anything", "delete"))
+
+	// non-repository entry is skipped, then denied
+	other := &OCITokenClaims{Access: []OCIAccessEntry{{Type: "registry", Name: "catalog", Actions: []string{"*"}}}}
+	assert.Error(t, service.AuthorizeOCITokenScope(other, "repo", "pull"))
+}
+
+func TestParseOCIScope_Invalid(t *testing.T) {
+	service, _ := setupTestService(t)
+	ctx := context.Background()
+
+	user, err := service.Register(ctx, &types.RegisterRequest{
+		Username: "scope-user", Email: "scope@example.com", Password: "testpassword123",
+	})
+	require.NoError(t, err)
+
+	// Malformed scopes are dropped; only the valid one survives in Access.
+	token, _, err := service.GenerateOCIToken(user.ID, "registry",
+		[]string{"bad", "repository::pull", "repository:repo:", "repository:repo:pull"}, time.Hour)
+	require.NoError(t, err)
+
+	_, claims, err := service.ValidateOCIToken(ctx, token)
+	require.NoError(t, err)
+	require.Len(t, claims.Access, 1)
+	assert.Equal(t, "repo", claims.Access[0].Name)
+}

--- a/internal/metadata/extract_test.go
+++ b/internal/metadata/extract_test.go
@@ -1,0 +1,126 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+func newPureService() *Service {
+	// Pure extract* helpers do not touch the DB.
+	return &Service{}
+}
+
+func TestExtractTags(t *testing.T) {
+	s := newPureService()
+	assert.Equal(t, []string{"a", "b"}, s.extractTags(map[string]interface{}{"tags": []string{"a", "b"}}))
+	assert.Equal(t, []string{"x", "y"}, s.extractTags(map[string]interface{}{"tags": []interface{}{"x", "y", 7}}))
+	assert.Equal(t, []string{"p", "q"}, s.extractTags(map[string]interface{}{"tags": "p,q"}))
+	assert.Empty(t, s.extractTags(map[string]interface{}{}))
+	assert.Empty(t, s.extractTags(map[string]interface{}{"tags": 42}))
+}
+
+func TestExtractKeywords(t *testing.T) {
+	s := newPureService()
+	assert.Equal(t, []string{"a", "b"}, s.extractKeywords(map[string]interface{}{"keywords": []string{"a", "b"}}))
+	assert.Equal(t, []string{"x"}, s.extractKeywords(map[string]interface{}{"keywords": []interface{}{"x", 1}}))
+	assert.Equal(t, []string{"p", "q"}, s.extractKeywords(map[string]interface{}{"keywords": "p,q"}))
+	assert.Empty(t, s.extractKeywords(map[string]interface{}{}))
+}
+
+func TestExtractDescriptionAndAuthor(t *testing.T) {
+	s := newPureService()
+	assert.Equal(t, "hello", s.extractDescription(map[string]interface{}{"description": "hello"}))
+	assert.Equal(t, "", s.extractDescription(map[string]interface{}{"description": 5}))
+	assert.Equal(t, "jane", s.extractAuthor(map[string]interface{}{"author": "jane"}))
+	assert.Equal(t, "", s.extractAuthor(map[string]interface{}{}))
+}
+
+func TestExtractSearchableText(t *testing.T) {
+	s := newPureService()
+	art := &types.Artifact{
+		Name: "mypkg",
+		Metadata: map[string]interface{}{
+			"description": "a great package",
+			"tags":        []string{"web", "api"},
+			"keywords":    []string{"http"},
+		},
+	}
+	text := s.extractSearchableText(art)
+	assert.Contains(t, text, "mypkg")
+	assert.Contains(t, text, "a great package")
+	assert.Contains(t, text, "web api")
+	assert.Contains(t, text, "http")
+
+	// Name only when metadata empty.
+	assert.Equal(t, "bare", s.extractSearchableText(&types.Artifact{Name: "bare", Metadata: map[string]interface{}{}}))
+}
+
+func TestExtractDependencies(t *testing.T) {
+	s := newPureService()
+	mapForm := s.extractDependencies(map[string]interface{}{
+		"dependencies": map[string]interface{}{"left-pad": "1.0.0", "bad": 5},
+	})
+	require.Len(t, mapForm, 1)
+	assert.Equal(t, "left-pad", mapForm[0].Name)
+
+	listForm := s.extractDependencies(map[string]interface{}{
+		"dependencies": []interface{}{
+			map[string]interface{}{"name": "react", "version": "18.0.0"},
+			map[string]interface{}{"version": "no-name"}, // skipped
+		},
+	})
+	require.Len(t, listForm, 1)
+	assert.Equal(t, "react", listForm[0].Name)
+
+	assert.Empty(t, s.extractDependencies(map[string]interface{}{}))
+}
+
+func TestExtractSecurityInfo(t *testing.T) {
+	s := newPureService()
+	assert.Nil(t, s.extractSecurityInfo(map[string]interface{}{}))
+
+	info := s.extractSecurityInfo(map[string]interface{}{
+		"security": map[string]interface{}{
+			"score": 8.5,
+			"vulnerabilities": []interface{}{
+				map[string]interface{}{"severity": "high", "description": "rce"},
+			},
+		},
+	})
+	require.NotNil(t, info)
+	require.Len(t, info.Vulnerabilities, 1)
+	assert.Equal(t, "high", info.Vulnerabilities[0].Severity)
+	require.NotNil(t, info.SecurityScore)
+	assert.Equal(t, 8.5, *info.SecurityScore)
+}
+
+func TestExtractQualityMetrics(t *testing.T) {
+	s := newPureService()
+	assert.Nil(t, s.extractQualityMetrics(map[string]interface{}{}))
+
+	m := s.extractQualityMetrics(map[string]interface{}{
+		"quality": map[string]interface{}{
+			"test_coverage":          90.0,
+			"code_quality_score":     7.0,
+			"documentation_coverage": 50.0,
+		},
+	})
+	require.NotNil(t, m)
+	require.NotNil(t, m.TestCoverage)
+	assert.Equal(t, 90.0, *m.TestCoverage)
+	assert.Equal(t, 7.0, *m.CodeQualityScore)
+	assert.Equal(t, 50.0, *m.DocumentationCoverage)
+}
+
+func TestExtractRegistrySpecificInfo(t *testing.T) {
+	s := newPureService()
+	got := s.extractRegistrySpecificInfo("npm", map[string]interface{}{
+		"npm": map[string]interface{}{"dist-tags": "latest"},
+	})
+	assert.Equal(t, "latest", got["dist-tags"])
+	assert.Nil(t, s.extractRegistrySpecificInfo("npm", map[string]interface{}{}))
+}

--- a/internal/registry/ownership.go
+++ b/internal/registry/ownership.go
@@ -196,16 +196,30 @@ func (os *OwnershipService) RemoveOwner(ctx context.Context, registry, packageNa
 		return fmt.Errorf("insufficient permissions to manage package ownership")
 	}
 
-	// Prevent removing the last owner
-	var ownerCount int64
-	if err := os.db.WithContext(ctx).Model(&types.PackageOwnership{}).
-		Where("package_key = ? AND role = ?", packageKey, RoleOwner).
-		Count(&ownerCount).Error; err != nil {
-		return fmt.Errorf("failed to count owners: %w", err)
+	// Prevent removing the last owner. Only the owner role is load-bearing here:
+	// removing a maintainer/contributor never drops the owner count, so the guard
+	// must check the target's role before blocking.
+	var target types.PackageOwnership
+	if err := os.db.WithContext(ctx).
+		Where("package_key = ? AND user_id = ?", packageKey, targetUserID).
+		First(&target).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return fmt.Errorf("user is not an owner of this package")
+		}
+		return fmt.Errorf("failed to look up ownership: %w", err)
 	}
 
-	if ownerCount <= 1 {
-		return fmt.Errorf("cannot remove the last owner of a package")
+	if target.Role == RoleOwner {
+		var ownerCount int64
+		if err := os.db.WithContext(ctx).Model(&types.PackageOwnership{}).
+			Where("package_key = ? AND role = ?", packageKey, RoleOwner).
+			Count(&ownerCount).Error; err != nil {
+			return fmt.Errorf("failed to count owners: %w", err)
+		}
+
+		if ownerCount <= 1 {
+			return fmt.Errorf("cannot remove the last owner of a package")
+		}
 	}
 
 	// Remove ownership

--- a/internal/registry/ownership_delegators_test.go
+++ b/internal/registry/ownership_delegators_test.go
@@ -1,0 +1,66 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceGetPackageOwners(t *testing.T) {
+	s, db, _ := setupTestService(t)
+	ctx := context.Background()
+	owner := createTestUserWithAdmin(t, db, false)
+
+	require.NoError(t, s.Ownership.EstablishInitialOwnership(ctx, "npm", "pkg", owner.ID))
+
+	owners, err := s.GetPackageOwners(ctx, "npm", "pkg")
+	require.NoError(t, err)
+	require.Len(t, owners, 1)
+	assert.Equal(t, owner.ID, owners[0].UserID)
+}
+
+func TestServiceAddPackageOwner(t *testing.T) {
+	s, db, _ := setupTestService(t)
+	ctx := context.Background()
+	owner := createTestUserWithAdmin(t, db, false)
+	target := createTestUserWithAdmin(t, db, false)
+
+	require.NoError(t, s.Ownership.EstablishInitialOwnership(ctx, "npm", "pkg", owner.ID))
+
+	// Owner can add another owner.
+	require.NoError(t, s.AddPackageOwner(ctx, "npm", "pkg", owner.ID, target.ID, "owner"))
+
+	owners, err := s.GetPackageOwners(ctx, "npm", "pkg")
+	require.NoError(t, err)
+	assert.Len(t, owners, 2)
+
+	// Non-owner cannot add.
+	stranger := createTestUserWithAdmin(t, db, false)
+	err = s.AddPackageOwner(ctx, "npm", "pkg", stranger.ID, uuid.New(), "owner")
+	assert.Error(t, err)
+}
+
+func TestServiceRemovePackageOwner(t *testing.T) {
+	s, db, _ := setupTestService(t)
+	ctx := context.Background()
+	owner := createTestUserWithAdmin(t, db, false)
+	target := createTestUserWithAdmin(t, db, false)
+
+	require.NoError(t, s.Ownership.EstablishInitialOwnership(ctx, "npm", "pkg", owner.ID))
+	require.NoError(t, s.AddPackageOwner(ctx, "npm", "pkg", owner.ID, target.ID, "owner"))
+
+	// Owner removes the added owner.
+	require.NoError(t, s.RemovePackageOwner(ctx, "npm", "pkg", owner.ID, target.ID))
+
+	owners, err := s.GetPackageOwners(ctx, "npm", "pkg")
+	require.NoError(t, err)
+	assert.Len(t, owners, 1)
+
+	// Non-owner cannot remove.
+	stranger := createTestUserWithAdmin(t, db, false)
+	err = s.RemovePackageOwner(ctx, "npm", "pkg", stranger.ID, owner.ID)
+	assert.Error(t, err)
+}

--- a/internal/registry/registries/cargo/registry_test.go
+++ b/internal/registry/registries/cargo/registry_test.go
@@ -37,7 +37,10 @@ func (m *mockStorage) Retrieve(ctx context.Context, path string) (io.ReadCloser,
 	}
 	return nil, io.EOF
 }
-func (m *mockStorage) Delete(ctx context.Context, path string) error { delete(m.data, path); return nil }
+func (m *mockStorage) Delete(ctx context.Context, path string) error {
+	delete(m.data, path)
+	return nil
+}
 func (m *mockStorage) Exists(ctx context.Context, path string) (bool, error) {
 	_, ok := m.data[path]
 	return ok, nil

--- a/internal/registry/registries/cargo/registry_test.go
+++ b/internal/registry/registries/cargo/registry_test.go
@@ -1,0 +1,129 @@
+package cargo
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+type mockStorage struct {
+	data    map[string][]byte
+	failPut bool
+}
+
+func newMockStorage() *mockStorage { return &mockStorage{data: make(map[string][]byte)} }
+
+func (m *mockStorage) Store(ctx context.Context, path string, content io.Reader, contentType string) error {
+	if m.failPut {
+		return fmt.Errorf("store failed")
+	}
+	data, err := io.ReadAll(content)
+	if err != nil {
+		return err
+	}
+	m.data[path] = data
+	return nil
+}
+func (m *mockStorage) Retrieve(ctx context.Context, path string) (io.ReadCloser, error) {
+	if data, ok := m.data[path]; ok {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+	return nil, io.EOF
+}
+func (m *mockStorage) Delete(ctx context.Context, path string) error { delete(m.data, path); return nil }
+func (m *mockStorage) Exists(ctx context.Context, path string) (bool, error) {
+	_, ok := m.data[path]
+	return ok, nil
+}
+func (m *mockStorage) GetSize(ctx context.Context, path string) (int64, error) {
+	if data, ok := m.data[path]; ok {
+		return int64(len(data)), nil
+	}
+	return 0, io.EOF
+}
+func (m *mockStorage) List(ctx context.Context, prefix string) ([]string, error) {
+	var out []string
+	for p := range m.data {
+		if len(prefix) == 0 || (len(p) >= len(prefix) && p[:len(prefix)] == prefix) {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+func TestNew(t *testing.T) {
+	assert.NotNil(t, New(newMockStorage(), nil))
+}
+
+func TestUpload(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		st := newMockStorage()
+		r := New(st, nil)
+		art := &types.Artifact{Name: "serde", Version: "1.0.0", StoragePath: "cargo/crates/serde/serde-1.0.0.crate"}
+		require.NoError(t, r.Upload(context.Background(), art, []byte("crate")))
+		assert.Equal(t, "application/gzip", art.ContentType)
+		assert.Equal(t, []byte("crate"), st.data[art.StoragePath])
+	})
+	t.Run("storage failure wrapped", func(t *testing.T) {
+		st := newMockStorage()
+		st.failPut = true
+		err := New(st, nil).Upload(context.Background(), &types.Artifact{StoragePath: "p"}, []byte("x"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to store Cargo package")
+	})
+}
+
+func TestValidate(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	tests := []struct {
+		name    string
+		art     *types.Artifact
+		content []byte
+		wantErr string
+	}{
+		{"valid", &types.Artifact{Name: "serde"}, []byte("x"), ""},
+		{"valid with underscore and dash", &types.Artifact{Name: "my_crate-2"}, []byte("x"), ""},
+		{"empty content", &types.Artifact{Name: "serde"}, nil, "empty crate content"},
+		{"invalid start with digit", &types.Artifact{Name: "1crate"}, []byte("x"), "invalid crate name format"},
+		{"invalid char", &types.Artifact{Name: "bad name"}, []byte("x"), "invalid crate name format"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := r.Validate(tt.art, tt.content)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetMetadata(t *testing.T) {
+	md, err := New(newMockStorage(), nil).GetMetadata([]byte("x"))
+	require.NoError(t, err)
+	assert.Equal(t, "cargo", md["format"])
+	assert.Equal(t, "crate", md["type"])
+}
+
+func TestGenerateStoragePath(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	assert.Equal(t, "cargo/crates/serde/serde-1.0.0.crate", r.GenerateStoragePath("serde", "1.0.0"))
+}
+
+func TestDeprecatedMethods(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	_, _, err := r.Download("n", "v")
+	assert.Error(t, err)
+	_, err = r.List(&types.ArtifactFilter{})
+	assert.Error(t, err)
+	assert.Error(t, r.Delete("n", "v"))
+}

--- a/internal/registry/registries/go/registry_test.go
+++ b/internal/registry/registries/go/registry_test.go
@@ -1,0 +1,148 @@
+package goregistry
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+// mockStorage is an in-memory BlobStorage for tests.
+type mockStorage struct {
+	data    map[string][]byte
+	failPut bool
+}
+
+func newMockStorage() *mockStorage {
+	return &mockStorage{data: make(map[string][]byte)}
+}
+
+func (m *mockStorage) Store(ctx context.Context, path string, content io.Reader, contentType string) error {
+	if m.failPut {
+		return fmt.Errorf("store failed")
+	}
+	data, err := io.ReadAll(content)
+	if err != nil {
+		return err
+	}
+	m.data[path] = data
+	return nil
+}
+
+func (m *mockStorage) Retrieve(ctx context.Context, path string) (io.ReadCloser, error) {
+	if data, ok := m.data[path]; ok {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+	return nil, io.EOF
+}
+
+func (m *mockStorage) Delete(ctx context.Context, path string) error {
+	delete(m.data, path)
+	return nil
+}
+
+func (m *mockStorage) Exists(ctx context.Context, path string) (bool, error) {
+	_, ok := m.data[path]
+	return ok, nil
+}
+
+func (m *mockStorage) GetSize(ctx context.Context, path string) (int64, error) {
+	if data, ok := m.data[path]; ok {
+		return int64(len(data)), nil
+	}
+	return 0, io.EOF
+}
+
+func (m *mockStorage) List(ctx context.Context, prefix string) ([]string, error) {
+	var out []string
+	for p := range m.data {
+		if len(prefix) == 0 || (len(p) >= len(prefix) && p[:len(prefix)] == prefix) {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+func TestNew(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	assert.NotNil(t, r)
+}
+
+func TestUpload(t *testing.T) {
+	t.Run("happy path stores content and sets content type", func(t *testing.T) {
+		st := newMockStorage()
+		r := New(st, nil)
+		art := &types.Artifact{Name: "example.com/mod", Version: "v1.0.0", StoragePath: "go/example.com/mod/@v/v1.0.0.zip"}
+		err := r.Upload(context.Background(), art, []byte("zipdata"))
+		require.NoError(t, err)
+		assert.Equal(t, "application/zip", art.ContentType)
+		assert.Equal(t, []byte("zipdata"), st.data[art.StoragePath])
+	})
+
+	t.Run("storage failure is wrapped", func(t *testing.T) {
+		st := newMockStorage()
+		st.failPut = true
+		r := New(st, nil)
+		art := &types.Artifact{Name: "m", Version: "v1.0.0", StoragePath: "p"}
+		err := r.Upload(context.Background(), art, []byte("x"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to store Go module")
+	})
+}
+
+func TestValidate(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	tests := []struct {
+		name    string
+		art     *types.Artifact
+		content []byte
+		wantErr string
+	}{
+		{"valid module", &types.Artifact{Name: "github.com/foo/bar", Version: "v1.2.3"}, []byte("x"), ""},
+		{"valid prerelease", &types.Artifact{Name: "example.com/x", Version: "v1.0.0-beta.1"}, []byte("x"), ""},
+		{"valid build metadata", &types.Artifact{Name: "example.com/x", Version: "v1.0.0+build.5"}, []byte("x"), ""},
+		{"empty content", &types.Artifact{Name: "example.com/x", Version: "v1.0.0"}, nil, "empty module content"},
+		{"invalid module path uppercase", &types.Artifact{Name: "Example.com/X", Version: "v1.0.0"}, []byte("x"), "invalid Go module path format"},
+		{"invalid version missing v", &types.Artifact{Name: "example.com/x", Version: "1.0.0"}, []byte("x"), "invalid semantic version format"},
+		{"invalid version partial", &types.Artifact{Name: "example.com/x", Version: "v1.0"}, []byte("x"), "invalid semantic version format"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := r.Validate(tt.art, tt.content)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetMetadata(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	md, err := r.GetMetadata([]byte("anything"))
+	require.NoError(t, err)
+	assert.Equal(t, "go", md["format"])
+	assert.Equal(t, "module", md["type"])
+}
+
+func TestGenerateStoragePath(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	assert.Equal(t, "go/example.com/mod/@v/v1.0.0.zip", r.GenerateStoragePath("example.com/mod", "v1.0.0"))
+}
+
+func TestDeprecatedMethods(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	_, _, err := r.Download("n", "v")
+	assert.Error(t, err)
+	_, err = r.List(&types.ArtifactFilter{})
+	assert.Error(t, err)
+	assert.Error(t, r.Delete("n", "v"))
+}

--- a/internal/registry/registries/helm/registry_test.go
+++ b/internal/registry/registries/helm/registry_test.go
@@ -37,7 +37,10 @@ func (m *mockStorage) Retrieve(ctx context.Context, path string) (io.ReadCloser,
 	}
 	return nil, io.EOF
 }
-func (m *mockStorage) Delete(ctx context.Context, path string) error { delete(m.data, path); return nil }
+func (m *mockStorage) Delete(ctx context.Context, path string) error {
+	delete(m.data, path)
+	return nil
+}
 func (m *mockStorage) Exists(ctx context.Context, path string) (bool, error) {
 	_, ok := m.data[path]
 	return ok, nil

--- a/internal/registry/registries/helm/registry_test.go
+++ b/internal/registry/registries/helm/registry_test.go
@@ -1,0 +1,129 @@
+package helm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+type mockStorage struct {
+	data    map[string][]byte
+	failPut bool
+}
+
+func newMockStorage() *mockStorage { return &mockStorage{data: make(map[string][]byte)} }
+
+func (m *mockStorage) Store(ctx context.Context, path string, content io.Reader, contentType string) error {
+	if m.failPut {
+		return fmt.Errorf("store failed")
+	}
+	data, err := io.ReadAll(content)
+	if err != nil {
+		return err
+	}
+	m.data[path] = data
+	return nil
+}
+func (m *mockStorage) Retrieve(ctx context.Context, path string) (io.ReadCloser, error) {
+	if data, ok := m.data[path]; ok {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+	return nil, io.EOF
+}
+func (m *mockStorage) Delete(ctx context.Context, path string) error { delete(m.data, path); return nil }
+func (m *mockStorage) Exists(ctx context.Context, path string) (bool, error) {
+	_, ok := m.data[path]
+	return ok, nil
+}
+func (m *mockStorage) GetSize(ctx context.Context, path string) (int64, error) {
+	if data, ok := m.data[path]; ok {
+		return int64(len(data)), nil
+	}
+	return 0, io.EOF
+}
+func (m *mockStorage) List(ctx context.Context, prefix string) ([]string, error) {
+	var out []string
+	for p := range m.data {
+		if len(prefix) == 0 || (len(p) >= len(prefix) && p[:len(prefix)] == prefix) {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+func TestNew(t *testing.T) {
+	assert.NotNil(t, New(newMockStorage(), nil))
+}
+
+func TestUpload(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		st := newMockStorage()
+		r := New(st, nil)
+		art := &types.Artifact{Name: "nginx", Version: "1.0.0", StoragePath: "helm/charts/nginx-1.0.0.tgz"}
+		require.NoError(t, r.Upload(context.Background(), art, []byte("tgz")))
+		assert.Equal(t, "application/gzip", art.ContentType)
+		assert.Equal(t, []byte("tgz"), st.data[art.StoragePath])
+	})
+	t.Run("storage failure wrapped", func(t *testing.T) {
+		st := newMockStorage()
+		st.failPut = true
+		err := New(st, nil).Upload(context.Background(), &types.Artifact{StoragePath: "p"}, []byte("x"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to store Helm chart")
+	})
+}
+
+func TestValidate(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	tests := []struct {
+		name    string
+		art     *types.Artifact
+		content []byte
+		wantErr string
+	}{
+		{"valid single char", &types.Artifact{Name: "a"}, []byte("x"), ""},
+		{"valid with dashes", &types.Artifact{Name: "my-chart-1"}, []byte("x"), ""},
+		{"empty content", &types.Artifact{Name: "nginx"}, nil, "empty chart content"},
+		{"invalid uppercase", &types.Artifact{Name: "Nginx"}, []byte("x"), "invalid Helm chart name format"},
+		{"invalid trailing dash", &types.Artifact{Name: "nginx-"}, []byte("x"), "invalid Helm chart name format"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := r.Validate(tt.art, tt.content)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetMetadata(t *testing.T) {
+	md, err := New(newMockStorage(), nil).GetMetadata([]byte("x"))
+	require.NoError(t, err)
+	assert.Equal(t, "helm", md["format"])
+	assert.Equal(t, "chart", md["type"])
+}
+
+func TestGenerateStoragePath(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	assert.Equal(t, "helm/charts/nginx-1.0.0.tgz", r.GenerateStoragePath("nginx", "1.0.0"))
+}
+
+func TestDeprecatedMethods(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	_, _, err := r.Download("n", "v")
+	assert.Error(t, err)
+	_, err = r.List(&types.ArtifactFilter{})
+	assert.Error(t, err)
+	assert.Error(t, r.Delete("n", "v"))
+}

--- a/internal/registry/registries/npm/registry_meta_test.go
+++ b/internal/registry/registries/npm/registry_meta_test.go
@@ -1,0 +1,76 @@
+package npm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMetadata_RichManifest(t *testing.T) {
+	registry, _, _ := setupTestRegistry(t)
+
+	packageData := map[string]interface{}{
+		"name":             "rich-pkg",
+		"version":          "2.0.0",
+		"description":      "a desc",
+		"license":          "MIT",
+		"keywords":         []string{"web", "api"},
+		"devDependencies":  map[string]string{"jest": "^29.0.0"},
+		"peerDependencies": map[string]string{"react": "^18.0.0"},
+		"deprecated":       "use v3",
+		"homepage":         "http://home",
+		"bugs":             map[string]interface{}{"url": "http://bugs"},
+		"scripts":          map[string]string{"build": "tsc"},
+		"engines":          map[string]string{"node": ">=18"},
+		"contributors":     []interface{}{"Alice"},
+		"author":           "Bob",
+		"repository":       map[string]interface{}{"type": "git", "url": "http://repo"},
+		"dist-tags":        map[string]string{"latest": "2.0.0", "beta": "2.1.0-beta"},
+		"time":             map[string]interface{}{"2.0.0": "2026-01-01T00:00:00Z"},
+	}
+
+	content, err := createTestPackageTarball(packageData)
+	require.NoError(t, err)
+
+	meta, err := registry.GetMetadata(content)
+	require.NoError(t, err)
+	assert.Equal(t, "a desc", meta["description"])
+	assert.Equal(t, "MIT", meta["license"])
+	assert.Contains(t, meta, "keywords")
+	assert.Contains(t, meta, "devDependencies")
+	assert.Contains(t, meta, "peerDependencies")
+	assert.Equal(t, "use v3", meta["deprecated"])
+	assert.Equal(t, "http://home", meta["homepage"])
+	assert.Contains(t, meta, "bugs")
+	assert.Contains(t, meta, "scripts")
+	assert.Contains(t, meta, "engines")
+	assert.Contains(t, meta, "contributors")
+	assert.Equal(t, "Bob", meta["author"])
+	assert.Contains(t, meta, "repository")
+	assert.Contains(t, meta, "dist-tags")
+	assert.Contains(t, meta, "time")
+}
+
+func TestGetMetadata_PrereleaseNoDistTag(t *testing.T) {
+	registry, _, _ := setupTestRegistry(t)
+
+	// Prerelease version with no dist-tags: should NOT set a default latest tag.
+	content, err := createTestPackageTarball(map[string]interface{}{
+		"name":    "pre-pkg",
+		"version": "1.0.0-alpha.1",
+	})
+	require.NoError(t, err)
+
+	meta, err := registry.GetMetadata(content)
+	require.NoError(t, err)
+	assert.NotContains(t, meta, "dist-tags")
+}
+
+func TestGetMetadata_InvalidTarballBasic(t *testing.T) {
+	registry, _, _ := setupTestRegistry(t)
+	meta, err := registry.GetMetadata([]byte("not a gzip tarball"))
+	require.NoError(t, err)
+	assert.Equal(t, "npm", meta["format"])
+	assert.NotContains(t, meta, "description")
+}

--- a/internal/registry/registries/nuget/registry_meta_test.go
+++ b/internal/registry/registries/nuget/registry_meta_test.go
@@ -1,0 +1,151 @@
+package nuget
+
+import (
+	"archive/zip"
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+func buildNupkg(t *testing.T, nuspec string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("mypkg.nuspec")
+	require.NoError(t, err)
+	_, err = w.Write([]byte(nuspec))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func TestGetMetadata_FullNuspec(t *testing.T) {
+	r := New(nil, nil)
+	nuspec := `<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>MyPkg</id>
+    <version>1.2.3</version>
+    <title>My Package</title>
+    <authors>Alice,Bob</authors>
+    <owners>Org</owners>
+    <description>a desc</description>
+    <summary>a summary</summary>
+    <tags>web api</tags>
+    <projectUrl>http://proj</projectUrl>
+    <licenseUrl>http://lic</licenseUrl>
+    <iconUrl>http://icon</iconUrl>
+    <copyright>2026</copyright>
+    <language>en-US</language>
+  </metadata>
+</package>`
+
+	meta, err := r.GetMetadata(buildNupkg(t, nuspec))
+	require.NoError(t, err)
+	assert.Equal(t, "MyPkg", meta["id"])
+	assert.Equal(t, "1.2.3", meta["version"])
+	assert.Equal(t, "a desc", meta["description"])
+	assert.Equal(t, "a summary", meta["summary"])
+	assert.Equal(t, []string{"Alice", "Bob"}, meta["authors"])
+	assert.Equal(t, []string{"Org"}, meta["owners"])
+	assert.Equal(t, []string{"web", "api"}, meta["tags"])
+	assert.Equal(t, "http://proj", meta["projectUrl"])
+	assert.Equal(t, "2026", meta["copyright"])
+}
+
+func TestGetMetadata_RichNuspec(t *testing.T) {
+	r := New(nil, nil)
+	nuspec := `<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>Rich</id>
+    <version>2.0.0</version>
+    <title>Rich Pkg</title>
+    <authors>A</authors>
+    <description>d</description>
+    <minClientVersion>3.3.0</minClientVersion>
+    <releaseNotes>notes</releaseNotes>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <developmentDependency>true</developmentDependency>
+    <license type="expression">MIT</license>
+    <repository type="git" url="http://repo" branch="main" commit="abc"/>
+    <packageTypes>
+      <packageType name="Dependency" version="1.0.0"/>
+    </packageTypes>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.Net" targetFramework="net6.0"/>
+    </frameworkAssemblies>
+    <dependencies>
+      <group targetFramework="net6.0">
+        <dependency id="Newtonsoft.Json" version="13.0.0" include="all" exclude="none"/>
+      </group>
+    </dependencies>
+  </metadata>
+</package>`
+
+	meta, err := r.GetMetadata(buildNupkg(t, nuspec))
+	require.NoError(t, err)
+	assert.Equal(t, "Rich", meta["id"])
+	assert.Equal(t, "notes", meta["releaseNotes"])
+	assert.Equal(t, true, meta["requireLicenseAcceptance"])
+	assert.Equal(t, true, meta["developmentDependency"])
+	assert.Equal(t, "3.3.0", meta["minClientVersion"])
+	assert.Contains(t, meta, "license")
+	assert.Contains(t, meta, "repository")
+	assert.Contains(t, meta, "packageTypes")
+	assert.Contains(t, meta, "frameworkAssemblies")
+	assert.Contains(t, meta, "dependencyGroups")
+}
+
+func TestGetMetadata_FlatDependencies(t *testing.T) {
+	r := New(nil, nil)
+	nuspec := `<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>Flat</id>
+    <version>1.0.0</version>
+    <authors>A</authors>
+    <description>d</description>
+    <dependencies>
+      <dependency id="left-pad" version="1.0.0"/>
+    </dependencies>
+  </metadata>
+</package>`
+
+	meta, err := r.GetMetadata(buildNupkg(t, nuspec))
+	require.NoError(t, err)
+	assert.Contains(t, meta, "dependencies")
+}
+
+func TestGetMetadata_InvalidZipFallsBackToBasic(t *testing.T) {
+	r := New(nil, nil)
+	meta, err := r.GetMetadata([]byte("not a zip"))
+	require.NoError(t, err)
+	assert.Equal(t, "nuget", meta["format"])
+	assert.NotContains(t, meta, "id")
+}
+
+func TestExtractNuspec_NotFound(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, _ := zw.Create("readme.txt")
+	_, _ = w.Write([]byte("hi"))
+	require.NoError(t, zw.Close())
+
+	_, err := extractNuspecFromNupkg(buf.Bytes())
+	assert.ErrorContains(t, err, ".nuspec file not found")
+}
+
+func TestIsSymbolPackage_Branches(t *testing.T) {
+	r := New(nil, nil)
+
+	assert.True(t, r.IsSymbolPackage(&types.Artifact{Metadata: map[string]interface{}{"packageType": "symbols"}}))
+	assert.True(t, r.IsSymbolPackage(&types.Artifact{Metadata: map[string]interface{}{"contentType": "application/vnd.nuget.symbolpackage"}}))
+	assert.True(t, r.IsSymbolPackage(&types.Artifact{ContentType: "application/vnd.nuget.symbolpackage"}))
+	assert.False(t, r.IsSymbolPackage(&types.Artifact{ContentType: "application/zip"}))
+	assert.False(t, r.IsSymbolPackage(&types.Artifact{Metadata: map[string]interface{}{"packageType": "regular"}}))
+}

--- a/internal/registry/registries/oci/oci_test.go
+++ b/internal/registry/registries/oci/oci_test.go
@@ -47,7 +47,10 @@ func (m *mockStorage) Retrieve(ctx context.Context, path string) (io.ReadCloser,
 	}
 	return nil, fmt.Errorf("not found")
 }
-func (m *mockStorage) Delete(ctx context.Context, path string) error { delete(m.data, path); return nil }
+func (m *mockStorage) Delete(ctx context.Context, path string) error {
+	delete(m.data, path)
+	return nil
+}
 func (m *mockStorage) Exists(ctx context.Context, path string) (bool, error) {
 	if m.failExists {
 		return false, fmt.Errorf("exists failed")

--- a/internal/registry/registries/oci/oci_test.go
+++ b/internal/registry/registries/oci/oci_test.go
@@ -1,0 +1,335 @@
+package oci
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+// mockStorage is an in-memory BlobStorage. Failure flags exercise error paths.
+type mockStorage struct {
+	data       map[string][]byte
+	failStore  bool
+	failExists bool
+	failSize   bool
+	failRetr   bool
+	failList   bool
+}
+
+func newMockStorage() *mockStorage { return &mockStorage{data: make(map[string][]byte)} }
+
+func (m *mockStorage) Store(ctx context.Context, path string, content io.Reader, contentType string) error {
+	if m.failStore {
+		return fmt.Errorf("store failed")
+	}
+	data, err := io.ReadAll(content)
+	if err != nil {
+		return err
+	}
+	m.data[path] = data
+	return nil
+}
+func (m *mockStorage) Retrieve(ctx context.Context, path string) (io.ReadCloser, error) {
+	if m.failRetr {
+		return nil, fmt.Errorf("retrieve failed")
+	}
+	if data, ok := m.data[path]; ok {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+	return nil, fmt.Errorf("not found")
+}
+func (m *mockStorage) Delete(ctx context.Context, path string) error { delete(m.data, path); return nil }
+func (m *mockStorage) Exists(ctx context.Context, path string) (bool, error) {
+	if m.failExists {
+		return false, fmt.Errorf("exists failed")
+	}
+	_, ok := m.data[path]
+	return ok, nil
+}
+func (m *mockStorage) GetSize(ctx context.Context, path string) (int64, error) {
+	if m.failSize {
+		return 0, fmt.Errorf("size failed")
+	}
+	if data, ok := m.data[path]; ok {
+		return int64(len(data)), nil
+	}
+	return 0, fmt.Errorf("not found")
+}
+func (m *mockStorage) List(ctx context.Context, prefix string) ([]string, error) {
+	if m.failList {
+		return nil, fmt.Errorf("list failed")
+	}
+	var out []string
+	for p := range m.data {
+		if strings.HasPrefix(p, prefix) {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+func digestOf(b []byte) string {
+	return fmt.Sprintf("sha256:%x", sha256.Sum256(b))
+}
+
+func TestValidate(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	tests := []struct {
+		name    string
+		art     *types.Artifact
+		content []byte
+		wantErr string
+	}{
+		{"valid tag", &types.Artifact{Name: "library/nginx", Version: "latest"}, []byte("x"), ""},
+		{"valid digest", &types.Artifact{Name: "app", Version: "sha256:" + strings.Repeat("a", 64)}, []byte("x"), ""},
+		{"empty content", &types.Artifact{Name: "app", Version: "latest"}, nil, "empty blob content"},
+		{"invalid image name", &types.Artifact{Name: "BadName", Version: "latest"}, []byte("x"), "invalid OCI image name format"},
+		{"invalid digest", &types.Artifact{Name: "app", Version: "sha256:zzz"}, []byte("x"), "invalid digest format"},
+		{"invalid tag", &types.Artifact{Name: "app", Version: "-bad"}, []byte("x"), "invalid tag format"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := r.Validate(tt.art, tt.content)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetMetadata(t *testing.T) {
+	md, err := New(newMockStorage(), nil).GetMetadata([]byte("abc"))
+	require.NoError(t, err)
+	assert.Equal(t, "oci", md["format"])
+	assert.Equal(t, 3, md["size"])
+}
+
+func TestGenerateStoragePath(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	assert.Equal(t, "oci/app/manifests/latest", r.GenerateStoragePath("app", "latest"))
+	assert.Equal(t, "oci/app/blobs/sha256/abc", r.GenerateStoragePath("app", "sha256:abc"))
+}
+
+func TestUploadAndDeprecated(t *testing.T) {
+	st := newMockStorage()
+	r := New(st, nil)
+	art := &types.Artifact{StoragePath: "oci/app/blobs/x"}
+	require.NoError(t, r.Upload(context.Background(), art, []byte("blob")))
+	assert.Equal(t, "application/octet-stream", art.ContentType)
+
+	st.failStore = true
+	require.Error(t, r.Upload(context.Background(), &types.Artifact{StoragePath: "p"}, []byte("x")))
+
+	_, _, err := r.Download("n", "v")
+	assert.Error(t, err)
+	_, err = r.List(&types.ArtifactFilter{})
+	assert.Error(t, err)
+	assert.Error(t, r.Delete("n", "v"))
+}
+
+func TestBlobLifecycle(t *testing.T) {
+	st := newMockStorage()
+	r := New(st, nil)
+	ctx := context.Background()
+	repo, digest := "app", "sha256:deadbeef"
+	path := fmt.Sprintf("oci/%s/blobs/%s", repo, digest)
+
+	// Not present yet.
+	exists, size, err := r.BlobExists(ctx, repo, digest)
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assert.Zero(t, size)
+
+	// GetBlob on missing blob errors.
+	_, _, err = r.GetBlob(ctx, repo, digest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "blob not found")
+
+	// Store then check.
+	st.data[path] = []byte("blobdata")
+	exists, size, err = r.BlobExists(ctx, repo, digest)
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.EqualValues(t, 8, size)
+
+	reader, size, err := r.GetBlob(ctx, repo, digest)
+	require.NoError(t, err)
+	got, _ := io.ReadAll(reader)
+	assert.Equal(t, []byte("blobdata"), got)
+	assert.EqualValues(t, 8, size)
+
+	require.NoError(t, r.DeleteBlob(ctx, repo, digest))
+	exists, _, _ = r.BlobExists(ctx, repo, digest)
+	assert.False(t, exists)
+}
+
+func TestBlobExistsError(t *testing.T) {
+	st := newMockStorage()
+	st.failExists = true
+	r := New(st, nil)
+	_, _, err := r.GetBlob(context.Background(), "app", "sha256:x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to check blob existence")
+}
+
+func TestManifestLifecycle(t *testing.T) {
+	st := newMockStorage()
+	r := New(st, nil)
+	ctx := context.Background()
+	repo, ref := "app", "v1"
+	manifest := []byte(`{"mediaType":"application/vnd.oci.image.manifest.v1+json"}`)
+
+	// Missing manifest reports not-exists without error.
+	exists, _, _, _, err := r.ManifestExists(ctx, repo, ref)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// GetManifest on missing errors.
+	_, _, _, err = r.GetManifest(ctx, repo, ref)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "manifest not found")
+
+	// Put manifest.
+	digest, err := r.PutManifest(ctx, repo, ref, bytes.NewReader(manifest), "application/vnd.oci.image.manifest.v1+json")
+	require.NoError(t, err)
+	assert.Equal(t, digestOf(manifest), digest)
+
+	// Exists now, with media type parsed from JSON.
+	exists, gotDigest, size, mediaType, err := r.ManifestExists(ctx, repo, ref)
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, digestOf(manifest), gotDigest)
+	assert.EqualValues(t, len(manifest), size)
+	assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", mediaType)
+
+	// Get manifest content back.
+	reader, gotDigest, _, err := r.GetManifest(ctx, repo, ref)
+	require.NoError(t, err)
+	body, _ := io.ReadAll(reader)
+	assert.Equal(t, manifest, body)
+	assert.Equal(t, digest, gotDigest)
+
+	// Delete.
+	require.NoError(t, r.DeleteManifest(ctx, repo, ref))
+	exists, _, _, _, _ = r.ManifestExists(ctx, repo, ref)
+	assert.False(t, exists)
+}
+
+func TestPutManifestInvalidJSON(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	_, err := r.PutManifest(context.Background(), "app", "v1", bytes.NewReader([]byte("not json")),
+		"application/vnd.docker.distribution.manifest.v2+json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid manifest JSON")
+}
+
+func TestListTagsAndRepositories(t *testing.T) {
+	st := newMockStorage()
+	r := New(st, nil)
+	ctx := context.Background()
+	st.data["oci/app/manifests/v1"] = []byte("m")
+	st.data["oci/app/manifests/v2"] = []byte("m")
+	st.data["oci/app/manifests/sha256:abc"] = []byte("m") // digest entries skipped
+	st.data["oci/other/blobs/sha256:x"] = []byte("b")
+
+	tags, err := r.ListTags(ctx, "app")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"v1", "v2"}, tags)
+
+	repos, err := r.ListRepositories(ctx)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"app", "other"}, repos)
+}
+
+func TestListErrors(t *testing.T) {
+	st := newMockStorage()
+	st.failList = true
+	r := New(st, nil)
+	_, err := r.ListTags(context.Background(), "app")
+	require.Error(t, err)
+	_, err = r.ListRepositories(context.Background())
+	require.Error(t, err)
+}
+
+func TestSessionManagerUploadFlow(t *testing.T) {
+	st := newMockStorage()
+	r := New(st, nil)
+	ctx := context.Background()
+
+	sess, err := r.StartBlobUpload(ctx, "app", "user1")
+	require.NoError(t, err)
+	assert.NotEmpty(t, sess.ID)
+
+	// Status before any chunk.
+	status, err := r.GetBlobUploadStatus(sess.ID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, status.Size)
+
+	// Two chunks → combined blob.
+	_, err = r.AppendBlobChunk(ctx, sess.ID, bytes.NewReader([]byte("hello ")), "")
+	require.NoError(t, err)
+	updated, err := r.AppendBlobChunk(ctx, sess.ID, bytes.NewReader([]byte("world")), "")
+	require.NoError(t, err)
+	assert.EqualValues(t, 11, updated.Size)
+
+	// Complete with correct digest.
+	full := []byte("hello world")
+	_, finalPath, err := r.CompleteBlobUpload(ctx, sess.ID, digestOf(full))
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("oci/app/blobs/%s", digestOf(full)), finalPath)
+	assert.Equal(t, full, st.data[finalPath])
+}
+
+func TestSessionManagerNegativePaths(t *testing.T) {
+	st := newMockStorage()
+	r := New(st, nil)
+	ctx := context.Background()
+
+	// Unknown session.
+	_, err := r.AppendBlobChunk(ctx, "nope", bytes.NewReader([]byte("x")), "")
+	assert.Error(t, err)
+	_, _, err = r.CompleteBlobUpload(ctx, "nope", "")
+	assert.Error(t, err)
+	_, err = r.GetBlobUploadStatus("nope")
+	assert.Error(t, err)
+	assert.Error(t, r.CancelBlobUpload(ctx, "nope"))
+
+	// Digest mismatch.
+	sess, _ := r.StartBlobUpload(ctx, "app", "u")
+	_, _ = r.AppendBlobChunk(ctx, sess.ID, bytes.NewReader([]byte("data")), "")
+	_, _, err = r.CompleteBlobUpload(ctx, sess.ID, "sha256:"+strings.Repeat("0", 64))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "digest mismatch")
+
+	// Cancel removes the session.
+	sess2, _ := r.StartBlobUpload(ctx, "app", "u")
+	require.NoError(t, r.CancelBlobUpload(ctx, sess2.ID))
+	_, err = r.GetBlobUploadStatus(sess2.ID)
+	assert.Error(t, err)
+}
+
+func TestCleanupExpiredSessions(t *testing.T) {
+	st := newMockStorage()
+	sm := NewSessionManager(st)
+	ctx := context.Background()
+	sess, _ := sm.StartUpload(ctx, "app", "u")
+
+	// Force expiry.
+	sess.LastUpdate = sess.LastUpdate.Add(-48 * 60 * 60 * 1e9)
+	sm.cleanupExpiredSessions()
+
+	_, exists := sm.GetSession(sess.ID)
+	assert.False(t, exists)
+}

--- a/internal/registry/registries/opa/registry_test.go
+++ b/internal/registry/registries/opa/registry_test.go
@@ -37,7 +37,10 @@ func (m *mockStorage) Retrieve(ctx context.Context, path string) (io.ReadCloser,
 	}
 	return nil, io.EOF
 }
-func (m *mockStorage) Delete(ctx context.Context, path string) error { delete(m.data, path); return nil }
+func (m *mockStorage) Delete(ctx context.Context, path string) error {
+	delete(m.data, path)
+	return nil
+}
 func (m *mockStorage) Exists(ctx context.Context, path string) (bool, error) {
 	_, ok := m.data[path]
 	return ok, nil

--- a/internal/registry/registries/opa/registry_test.go
+++ b/internal/registry/registries/opa/registry_test.go
@@ -1,0 +1,114 @@
+package opa
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+type mockStorage struct {
+	data    map[string][]byte
+	failPut bool
+}
+
+func newMockStorage() *mockStorage { return &mockStorage{data: make(map[string][]byte)} }
+
+func (m *mockStorage) Store(ctx context.Context, path string, content io.Reader, contentType string) error {
+	if m.failPut {
+		return fmt.Errorf("store failed")
+	}
+	data, err := io.ReadAll(content)
+	if err != nil {
+		return err
+	}
+	m.data[path] = data
+	return nil
+}
+func (m *mockStorage) Retrieve(ctx context.Context, path string) (io.ReadCloser, error) {
+	if data, ok := m.data[path]; ok {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+	return nil, io.EOF
+}
+func (m *mockStorage) Delete(ctx context.Context, path string) error { delete(m.data, path); return nil }
+func (m *mockStorage) Exists(ctx context.Context, path string) (bool, error) {
+	_, ok := m.data[path]
+	return ok, nil
+}
+func (m *mockStorage) GetSize(ctx context.Context, path string) (int64, error) {
+	if data, ok := m.data[path]; ok {
+		return int64(len(data)), nil
+	}
+	return 0, io.EOF
+}
+func (m *mockStorage) List(ctx context.Context, prefix string) ([]string, error) {
+	var out []string
+	for p := range m.data {
+		if len(prefix) == 0 || (len(p) >= len(prefix) && p[:len(prefix)] == prefix) {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+func TestNew(t *testing.T) {
+	assert.NotNil(t, New(newMockStorage(), nil))
+}
+
+func TestUpload(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		st := newMockStorage()
+		r := New(st, nil)
+		art := &types.Artifact{Name: "policy", Version: "1.0.0", StoragePath: "opa/bundles/policy/1.0.0.tar.gz"}
+		require.NoError(t, r.Upload(context.Background(), art, []byte("bundle")))
+		assert.Equal(t, "application/gzip", art.ContentType)
+		assert.Equal(t, []byte("bundle"), st.data[art.StoragePath])
+	})
+	t.Run("storage failure wrapped", func(t *testing.T) {
+		st := newMockStorage()
+		st.failPut = true
+		err := New(st, nil).Upload(context.Background(), &types.Artifact{StoragePath: "p"}, []byte("x"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to store OPA bundle")
+	})
+}
+
+func TestValidate(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	t.Run("valid non-empty", func(t *testing.T) {
+		assert.NoError(t, r.Validate(&types.Artifact{Name: "policy"}, []byte("rego")))
+	})
+	t.Run("empty content", func(t *testing.T) {
+		err := r.Validate(&types.Artifact{Name: "policy"}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty bundle content")
+	})
+}
+
+func TestGetMetadata(t *testing.T) {
+	md, err := New(newMockStorage(), nil).GetMetadata([]byte("x"))
+	require.NoError(t, err)
+	assert.Equal(t, "opa", md["format"])
+	assert.Equal(t, "bundle", md["type"])
+}
+
+func TestGenerateStoragePath(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	assert.Equal(t, "opa/bundles/policy/1.0.0.tar.gz", r.GenerateStoragePath("policy", "1.0.0"))
+}
+
+func TestDeprecatedMethods(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	_, _, err := r.Download("n", "v")
+	assert.Error(t, err)
+	_, err = r.List(&types.ArtifactFilter{})
+	assert.Error(t, err)
+	assert.Error(t, r.Delete("n", "v"))
+}

--- a/internal/registry/registries/rubygems/registry_test.go
+++ b/internal/registry/registries/rubygems/registry_test.go
@@ -37,7 +37,10 @@ func (m *mockStorage) Retrieve(ctx context.Context, path string) (io.ReadCloser,
 	}
 	return nil, io.EOF
 }
-func (m *mockStorage) Delete(ctx context.Context, path string) error { delete(m.data, path); return nil }
+func (m *mockStorage) Delete(ctx context.Context, path string) error {
+	delete(m.data, path)
+	return nil
+}
 func (m *mockStorage) Exists(ctx context.Context, path string) (bool, error) {
 	_, ok := m.data[path]
 	return ok, nil

--- a/internal/registry/registries/rubygems/registry_test.go
+++ b/internal/registry/registries/rubygems/registry_test.go
@@ -1,0 +1,132 @@
+package rubygems
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+type mockStorage struct {
+	data    map[string][]byte
+	failPut bool
+}
+
+func newMockStorage() *mockStorage { return &mockStorage{data: make(map[string][]byte)} }
+
+func (m *mockStorage) Store(ctx context.Context, path string, content io.Reader, contentType string) error {
+	if m.failPut {
+		return fmt.Errorf("store failed")
+	}
+	data, err := io.ReadAll(content)
+	if err != nil {
+		return err
+	}
+	m.data[path] = data
+	return nil
+}
+func (m *mockStorage) Retrieve(ctx context.Context, path string) (io.ReadCloser, error) {
+	if data, ok := m.data[path]; ok {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+	return nil, io.EOF
+}
+func (m *mockStorage) Delete(ctx context.Context, path string) error { delete(m.data, path); return nil }
+func (m *mockStorage) Exists(ctx context.Context, path string) (bool, error) {
+	_, ok := m.data[path]
+	return ok, nil
+}
+func (m *mockStorage) GetSize(ctx context.Context, path string) (int64, error) {
+	if data, ok := m.data[path]; ok {
+		return int64(len(data)), nil
+	}
+	return 0, io.EOF
+}
+func (m *mockStorage) List(ctx context.Context, prefix string) ([]string, error) {
+	var out []string
+	for p := range m.data {
+		if len(prefix) == 0 || (len(p) >= len(prefix) && p[:len(prefix)] == prefix) {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+func TestNew(t *testing.T) {
+	assert.NotNil(t, New(newMockStorage(), nil))
+}
+
+func TestUpload(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		st := newMockStorage()
+		r := New(st, nil)
+		art := &types.Artifact{Name: "rails.gem", Version: "7.0.0", StoragePath: "rubygems/gems/rails-7.0.0.gem"}
+		require.NoError(t, r.Upload(context.Background(), art, []byte("gem")))
+		assert.Equal(t, "application/octet-stream", art.ContentType)
+		assert.Equal(t, []byte("gem"), st.data[art.StoragePath])
+	})
+	t.Run("storage failure wrapped", func(t *testing.T) {
+		st := newMockStorage()
+		st.failPut = true
+		err := New(st, nil).Upload(context.Background(), &types.Artifact{StoragePath: "p"}, []byte("x"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to store Ruby gem")
+	})
+}
+
+func TestValidate(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	tests := []struct {
+		name    string
+		art     *types.Artifact
+		content []byte
+		wantErr string
+	}{
+		{"valid", &types.Artifact{Name: "rails.gem"}, []byte("x"), ""},
+		// Extension check lowercases but TrimSuffix is case-sensitive, so an
+		// uppercase ".GEM" passes the extension gate then fails name validation.
+		{"uppercase extension fails name check", &types.Artifact{Name: "rails.GEM"}, []byte("x"), "invalid gem name format"},
+		{"valid with underscore", &types.Artifact{Name: "my_gem-2.gem"}, []byte("x"), ""},
+		{"empty content", &types.Artifact{Name: "rails.gem"}, nil, "empty gem content"},
+		{"missing extension", &types.Artifact{Name: "rails"}, []byte("x"), "invalid gem file extension"},
+		{"invalid name char", &types.Artifact{Name: "bad name.gem"}, []byte("x"), "invalid gem name format"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := r.Validate(tt.art, tt.content)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetMetadata(t *testing.T) {
+	md, err := New(newMockStorage(), nil).GetMetadata([]byte("x"))
+	require.NoError(t, err)
+	assert.Equal(t, "rubygems", md["format"])
+	assert.Equal(t, "gem", md["type"])
+}
+
+func TestGenerateStoragePath(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	assert.Equal(t, "rubygems/gems/rails-7.0.0.gem", r.GenerateStoragePath("rails", "7.0.0"))
+}
+
+func TestDeprecatedMethods(t *testing.T) {
+	r := New(newMockStorage(), nil)
+	_, _, err := r.Download("n", "v")
+	assert.Error(t, err)
+	_, err = r.List(&types.ArtifactFilter{})
+	assert.Error(t, err)
+	assert.Error(t, r.Delete("n", "v"))
+}

--- a/internal/registry/service.go
+++ b/internal/registry/service.go
@@ -400,20 +400,25 @@ func (s *Service) List(ctx context.Context, filter *types.ArtifactFilter) ([]*ty
 	return artifacts, total, nil
 }
 
-// Delete removes an artifact
+// Delete removes an artifact. An empty version deletes every version of the
+// package (used by unpublish-style flows).
 func (s *Service) Delete(ctx context.Context, registryType, name, version string, userID uuid.UUID) error {
-	// Get artifact
-	var artifact types.Artifact
-	if err := s.DB.Where("LOWER(name) = LOWER(?) AND version = ? AND registry = ?",
-		name, version, registryType).First(&artifact).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
-			return fmt.Errorf("artifact not found: %s:%s", name, version)
-		}
+	query := s.DB.Where("LOWER(name) = LOWER(?) AND registry = ?", name, registryType)
+	if version != "" {
+		query = query.Where("version = ?", version)
+	}
+
+	var artifacts []types.Artifact
+	if err := query.Find(&artifacts).Error; err != nil {
 		return fmt.Errorf("failed to get artifact: %w", err)
 	}
 
-	// Check ownership permissions
-	canDelete, err := s.Ownership.CanUserDelete(ctx, registryType, artifact.Name, userID)
+	if len(artifacts) == 0 {
+		return fmt.Errorf("artifact not found: %s:%s", name, version)
+	}
+
+	// Check ownership permissions once against the resolved package name.
+	canDelete, err := s.Ownership.CanUserDelete(ctx, registryType, artifacts[0].Name, userID)
 	if err != nil {
 		return fmt.Errorf("failed to check delete permissions: %w", err)
 	}
@@ -422,14 +427,14 @@ func (s *Service) Delete(ctx context.Context, registryType, name, version string
 		return fmt.Errorf("insufficient permissions to delete artifact")
 	}
 
-	// Delete from storage
-	if err := s.Storage.Delete(ctx, artifact.StoragePath); err != nil {
-		return fmt.Errorf("failed to delete artifact from storage: %w", err)
-	}
-
-	// Delete from database
-	if err := s.DB.Delete(&artifact).Error; err != nil {
-		return fmt.Errorf("failed to delete artifact from database: %w", err)
+	for i := range artifacts {
+		artifact := &artifacts[i]
+		if err := s.Storage.Delete(ctx, artifact.StoragePath); err != nil {
+			return fmt.Errorf("failed to delete artifact from storage: %w", err)
+		}
+		if err := s.DB.Delete(artifact).Error; err != nil {
+			return fmt.Errorf("failed to delete artifact from database: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/registry/service_extra_test.go
+++ b/internal/registry/service_extra_test.go
@@ -1,0 +1,128 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/internal/registry/upstream"
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+func TestUpload_RegistryDisabled(t *testing.T) {
+	service, db, _ := setupTestService(t)
+	user := createTestUser(t, db)
+	ctx := context.Background()
+
+	require.NoError(t, service.Settings.DisableRegistry(ctx, "test", user.ID))
+
+	mockHandler := &MockHandler{}
+	service.handlers["test"] = mockHandler
+
+	artifact, err := service.Upload(ctx, "test", "pkg", "1.0.0", bytes.NewReader([]byte("x")), user.ID)
+	assert.Error(t, err)
+	assert.Nil(t, artifact)
+	assert.Contains(t, err.Error(), "disabled")
+}
+
+func TestUpload_MetadataFailure(t *testing.T) {
+	service, db, _ := setupTestService(t)
+	user := createTestUser(t, db)
+	ctx := context.Background()
+
+	mockHandler := &MockHandler{}
+	service.handlers["test"] = mockHandler
+
+	content := []byte("c")
+	mockHandler.On("Validate", mock.AnythingOfType("*types.Artifact"), content).Return(nil)
+	mockHandler.On("GetMetadata", content).Return(map[string]interface{}{}, errors.New("boom"))
+
+	artifact, err := service.Upload(ctx, "test", "pkg", "1.0.0", bytes.NewReader(content), user.ID)
+	assert.Error(t, err)
+	assert.Nil(t, artifact)
+	assert.Contains(t, err.Error(), "extract metadata")
+	mockHandler.AssertExpectations(t)
+}
+
+func TestUpload_HandlerUploadFailure(t *testing.T) {
+	service, db, _ := setupTestService(t)
+	user := createTestUser(t, db)
+	ctx := context.Background()
+
+	mockHandler := &MockHandler{}
+	service.handlers["test"] = mockHandler
+
+	content := []byte("c")
+	mockHandler.On("Validate", mock.AnythingOfType("*types.Artifact"), content).Return(nil)
+	mockHandler.On("GetMetadata", content).Return(map[string]interface{}{}, nil)
+	mockHandler.On("GenerateStoragePath", "pkg", "1.0.0").Return("test/pkg/1.0.0/artifact")
+	mockHandler.On("Upload", ctx, mock.AnythingOfType("*types.Artifact"), content).Return(errors.New("store fail"))
+
+	artifact, err := service.Upload(ctx, "test", "pkg", "1.0.0", bytes.NewReader(content), user.ID)
+	assert.Error(t, err)
+	assert.Nil(t, artifact)
+	assert.Contains(t, err.Error(), "failed to upload artifact")
+	mockHandler.AssertExpectations(t)
+}
+
+func TestDownload_RegistryDisabled(t *testing.T) {
+	service, db, _ := setupTestService(t)
+	user := createTestUser(t, db)
+	ctx := context.Background()
+
+	require.NoError(t, service.Settings.DisableRegistry(ctx, "test", user.ID))
+	service.handlers["test"] = &MockHandler{}
+
+	_, _, err := service.Download(ctx, "test", "pkg", "1.0.0")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "disabled")
+}
+
+func TestDownload_StorageRetrieveFailure(t *testing.T) {
+	service, db, mockStorage := setupTestService(t)
+	user := createTestUser(t, db)
+	ctx := context.Background()
+	service.handlers["test"] = &MockHandler{}
+
+	art := &types.Artifact{
+		Name: "pkg", Version: "1.0.0", Registry: "test",
+		StoragePath: "test/pkg/1.0.0/artifact", PublishedBy: user.ID,
+	}
+	require.NoError(t, db.Create(art).Error)
+
+	mockStorage.On("Retrieve", ctx, "test/pkg/1.0.0/artifact").
+		Return(io.NopCloser(bytes.NewReader(nil)), errors.New("gone"))
+
+	_, _, err := service.Download(ctx, "test", "pkg", "1.0.0")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to retrieve artifact")
+	mockStorage.AssertExpectations(t)
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("read fail") }
+
+func TestUpload_ContentReadFailure(t *testing.T) {
+	service, db, _ := setupTestService(t)
+	user := createTestUser(t, db)
+	ctx := context.Background()
+	service.handlers["test"] = &MockHandler{}
+
+	artifact, err := service.Upload(ctx, "test", "pkg", "1.0.0", errReader{}, user.ID)
+	assert.Error(t, err)
+	assert.Nil(t, artifact)
+	assert.Contains(t, err.Error(), "failed to read content")
+}
+
+func TestEnsureUpstreamCached_ProxyDisabled(t *testing.T) {
+	service, _, _ := setupTestService(t)
+	err := service.EnsureUpstreamCached(context.Background(), "npm", "pkg", "1.0.0", "artifact")
+	assert.ErrorIs(t, err, upstream.ErrProxyDisabled)
+}

--- a/internal/registry/settings_service_test.go
+++ b/internal/registry/settings_service_test.go
@@ -1,0 +1,102 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/types"
+)
+
+func setupSettingsService(t *testing.T) (*RegistrySettingsService, *types.User) {
+	db := setupTestDB(t)
+	user := &types.User{Username: "admin", Email: "a@b.c", Password: "x", IsActive: true, IsAdmin: true}
+	require.NoError(t, db.Create(user).Error)
+	return NewRegistrySettingsService(db.DB), user
+}
+
+func TestIsRegistryEnabled(t *testing.T) {
+	s, _ := setupSettingsService(t)
+	ctx := context.Background()
+
+	enabled, err := s.IsRegistryEnabled(ctx, "npm")
+	require.NoError(t, err)
+	assert.True(t, enabled)
+
+	// Unknown registry → disabled, no error.
+	enabled, err = s.IsRegistryEnabled(ctx, "ghost")
+	require.NoError(t, err)
+	assert.False(t, enabled)
+}
+
+func TestEnableDisableRegistry(t *testing.T) {
+	s, user := setupSettingsService(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.DisableRegistry(ctx, "npm", user.ID))
+	enabled, _ := s.IsRegistryEnabled(ctx, "npm")
+	assert.False(t, enabled)
+
+	require.NoError(t, s.EnableRegistry(ctx, "npm", user.ID))
+	enabled, _ = s.IsRegistryEnabled(ctx, "npm")
+	assert.True(t, enabled)
+
+	// Not found cases.
+	assert.Error(t, s.EnableRegistry(ctx, "ghost", user.ID))
+	assert.Error(t, s.DisableRegistry(ctx, "ghost", user.ID))
+}
+
+func TestGetRegistrySettings(t *testing.T) {
+	s, _ := setupSettingsService(t)
+	settings, err := s.GetRegistrySettings(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, settings)
+	found := false
+	for _, st := range settings {
+		if st.RegistryName == "npm" {
+			found = true
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestGetRegistrySetting(t *testing.T) {
+	s, _ := setupSettingsService(t)
+	ctx := context.Background()
+
+	got, err := s.GetRegistrySetting(ctx, "npm")
+	require.NoError(t, err)
+	assert.Equal(t, "npm", got.RegistryName)
+
+	_, err = s.GetRegistrySetting(ctx, "ghost")
+	assert.Error(t, err)
+}
+
+func TestUpdateRegistryDescription(t *testing.T) {
+	s, user := setupSettingsService(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.UpdateRegistryDescription(ctx, "npm", "updated desc", user.ID))
+	got, _ := s.GetRegistrySetting(ctx, "npm")
+	assert.Equal(t, "updated desc", got.Description)
+
+	assert.Error(t, s.UpdateRegistryDescription(ctx, "ghost", "x", user.ID))
+}
+
+func TestStorageService(t *testing.T) {
+	db := setupTestDB(t)
+	storage := &MockBlobStorage{}
+	svc := NewStorageService(db, storage)
+	assert.Equal(t, storage, svc.GetStorage())
+	assert.Equal(t, db, svc.GetDB())
+}
+
+func TestRegistrySettingBeforeCreate(t *testing.T) {
+	db := setupTestDB(t)
+	setting := &types.RegistrySetting{RegistryName: "uniquereg", Enabled: true}
+	require.NoError(t, db.Create(setting).Error)
+	assert.NotEqual(t, uuid.Nil, setting.ID)
+}

--- a/internal/registry/upstream/upstream_test.go
+++ b/internal/registry/upstream/upstream_test.go
@@ -1,0 +1,295 @@
+package upstream
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/config"
+)
+
+func enabledCfg(registry, upstream string) config.ProxyConfig {
+	cfg := config.ProxyConfig{Enabled: true, TimeoutSeconds: 5}
+	rc := config.ProxyRegistryConfig{Enabled: true, Upstream: upstream}
+	switch registry {
+	case "npm":
+		cfg.Registries.NPM = rc
+	case "nuget":
+		cfg.Registries.NuGet = rc
+	case "maven":
+		cfg.Registries.Maven = rc
+	case "go":
+		cfg.Registries.Go = rc
+	case "helm":
+		cfg.Registries.Helm = rc
+	case "cargo":
+		cfg.Registries.Cargo = rc
+	case "rubygems":
+		cfg.Registries.RubyGems = rc
+	case "opa":
+		cfg.Registries.OPA = rc
+	case "oci":
+		cfg.Registries.OCI = rc
+	}
+	return cfg
+}
+
+func TestIsEnabled(t *testing.T) {
+	t.Run("disabled globally", func(t *testing.T) {
+		s := NewService(config.ProxyConfig{Enabled: false})
+		assert.False(t, s.IsEnabled("npm"))
+	})
+	t.Run("unknown registry", func(t *testing.T) {
+		s := NewService(config.ProxyConfig{Enabled: true})
+		assert.False(t, s.IsEnabled("bogus"))
+	})
+	t.Run("registry disabled", func(t *testing.T) {
+		cfg := config.ProxyConfig{Enabled: true}
+		cfg.Registries.NPM = config.ProxyRegistryConfig{Enabled: false, Upstream: "https://x"}
+		assert.False(t, NewService(cfg).IsEnabled("npm"))
+	})
+	t.Run("empty upstream", func(t *testing.T) {
+		cfg := config.ProxyConfig{Enabled: true}
+		cfg.Registries.NPM = config.ProxyRegistryConfig{Enabled: true, Upstream: "  "}
+		assert.False(t, NewService(cfg).IsEnabled("npm"))
+	})
+	t.Run("enabled", func(t *testing.T) {
+		assert.True(t, NewService(enabledCfg("npm", "https://registry.npmjs.org")).IsEnabled("npm"))
+	})
+}
+
+func TestNewServiceDefaultTimeout(t *testing.T) {
+	s := NewService(config.ProxyConfig{TimeoutSeconds: 0})
+	assert.NotNil(t, s.client)
+}
+
+func TestAdapterBuildURL(t *testing.T) {
+	s := NewService(config.ProxyConfig{})
+	tests := []struct {
+		registry string
+		req      ProxyRequest
+		want     string
+		wantErr  bool
+	}{
+		{"npm", ProxyRequest{Name: "lodash", Version: "4.17.21"}, "https://up/lodash/-/lodash-4.17.21.tgz", false},
+		{"npm", ProxyRequest{Name: "@scope/pkg", Version: "1.0.0"}, "https://up/@scope%2fpkg/-/pkg-1.0.0.tgz", false},
+		{"nuget", ProxyRequest{Name: "Newtonsoft.Json", Version: "13.0.1"}, "https://up/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg", false},
+		{"maven", ProxyRequest{Name: "com.google.guava:guava", Version: "32.0"}, "https://up/com/google/guava/guava/32.0/guava-32.0.jar", false},
+		{"maven", ProxyRequest{Name: "bad-coords", Version: "1.0"}, "", true},
+		{"go", ProxyRequest{Name: "github.com/foo/bar", Version: "v1.0.0"}, "https://up/github.com/foo/bar/@v/v1.0.0.zip", false},
+		{"helm", ProxyRequest{Name: "nginx", Version: "1.0.0"}, "https://up/nginx-1.0.0.tgz", false},
+		{"cargo", ProxyRequest{Name: "serde", Version: "1.0.0"}, "https://up/api/v1/crates/serde/1.0.0/download", false},
+		{"rubygems", ProxyRequest{Name: "rails", Version: "7.0.0"}, "https://up/downloads/rails-7.0.0.gem", false},
+		{"opa", ProxyRequest{Name: "policy", Version: "1.0.0"}, "https://up/bundles/policy/1.0.0.tar.gz", false},
+		{"oci", ProxyRequest{Name: "app", Version: "latest", Resource: "manifest"}, "https://up/v2/app/manifests/latest", false},
+		{"oci", ProxyRequest{Name: "app", Version: "sha256:x", Resource: "blob"}, "https://up/v2/app/blobs/sha256:x", false},
+		{"oci", ProxyRequest{Name: "app", Version: "latest", Resource: "bogus"}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.registry+"/"+tt.req.Resource, func(t *testing.T) {
+			a := s.adapters[tt.registry]
+			require.NotNil(t, a)
+			got, err := a.BuildURL("https://up/", tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestAdapterAcceptHeaders(t *testing.T) {
+	s := NewService(config.ProxyConfig{})
+	assert.Equal(t, "application/zip", s.adapters["go"].AcceptHeader(ProxyRequest{}))
+	assert.Contains(t, s.adapters["oci"].AcceptHeader(ProxyRequest{Resource: "manifest"}), "manifest.v1+json")
+	assert.Equal(t, "application/octet-stream", s.adapters["oci"].AcceptHeader(ProxyRequest{Resource: "blob"}))
+}
+
+func TestFetchDisabled(t *testing.T) {
+	s := NewService(config.ProxyConfig{Enabled: false})
+	_, err := s.Fetch(context.Background(), ProxyRequest{Registry: "npm"})
+	assert.ErrorIs(t, err, ErrProxyDisabled)
+}
+
+func TestFetchHappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer srv.Close()
+
+	s := NewService(enabledCfg("helm", srv.URL))
+	got, err := s.Fetch(context.Background(), ProxyRequest{Registry: "helm", Name: "nginx", Version: "1.0.0"})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("payload"), got.Content)
+	assert.Equal(t, "application/gzip", got.ContentType)
+}
+
+func TestFetchNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	s := NewService(enabledCfg("helm", srv.URL))
+	_, err := s.Fetch(context.Background(), ProxyRequest{Registry: "helm", Name: "x", Version: "1"})
+	assert.ErrorIs(t, err, ErrUpstreamNotFound)
+}
+
+func TestFetchUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	s := NewService(enabledCfg("helm", srv.URL))
+	_, err := s.Fetch(context.Background(), ProxyRequest{Registry: "helm", Name: "x", Version: "1"})
+	assert.ErrorIs(t, err, ErrUpstreamUnauthorized)
+}
+
+func TestFetchUnexpectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	s := NewService(enabledCfg("helm", srv.URL))
+	_, err := s.Fetch(context.Background(), ProxyRequest{Registry: "helm", Name: "x", Version: "1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 500")
+}
+
+func TestFetchTooLarge(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("0123456789"))
+	}))
+	defer srv.Close()
+	cfg := enabledCfg("helm", srv.URL)
+	cfg.MaxArtifactBytes = 5
+	s := NewService(cfg)
+	_, err := s.Fetch(context.Background(), ProxyRequest{Registry: "helm", Name: "x", Version: "1"})
+	assert.ErrorIs(t, err, ErrUpstreamTooLarge)
+}
+
+func TestFetchDefaultContentType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header()["Content-Type"] = nil // suppress net/http content sniffing
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("x"))
+	}))
+	defer srv.Close()
+	s := NewService(enabledCfg("helm", srv.URL))
+	got, err := s.Fetch(context.Background(), ProxyRequest{Registry: "helm", Name: "x", Version: "1"})
+	require.NoError(t, err)
+	assert.Equal(t, "application/octet-stream", got.ContentType)
+}
+
+func TestFetchBuildURLError(t *testing.T) {
+	s := NewService(enabledCfg("maven", "https://up"))
+	_, err := s.Fetch(context.Background(), ProxyRequest{Registry: "maven", Name: "no-colon", Version: "1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid maven coordinates")
+}
+
+func TestFetchOCIBearerFlow(t *testing.T) {
+	var tokenSrv *httptest.Server
+	tokenSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "myservice", r.URL.Query().Get("service"))
+		_, _ = w.Write([]byte(`{"token":"abc123"}`))
+	}))
+	defer tokenSrv.Close()
+
+	registrySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer abc123" {
+			_, _ = w.Write([]byte("manifest-bytes"))
+			return
+		}
+		w.Header().Set("WWW-Authenticate", `Bearer realm="`+tokenSrv.URL+`",service="myservice",scope="repository:app:pull"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer registrySrv.Close()
+
+	s := NewService(enabledCfg("oci", registrySrv.URL))
+	got, err := s.Fetch(context.Background(), ProxyRequest{Registry: "oci", Name: "app", Version: "latest", Resource: "manifest"})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("manifest-bytes"), got.Content)
+}
+
+func TestFetchOCIUnauthorizedNoChallenge(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	s := NewService(enabledCfg("oci", srv.URL))
+	_, err := s.Fetch(context.Background(), ProxyRequest{Registry: "oci", Name: "app", Version: "latest", Resource: "manifest"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bearer token")
+}
+
+func TestParseBearerChallenge(t *testing.T) {
+	got := parseBearerChallenge(`realm="https://auth.example.com/token",service="reg",scope="pull"`)
+	assert.Equal(t, "https://auth.example.com/token", got["realm"])
+	assert.Equal(t, "reg", got["service"])
+	assert.Equal(t, "pull", got["scope"])
+	// Malformed entries are skipped.
+	got2 := parseBearerChallenge(`bad,realm="r"`)
+	assert.Equal(t, "r", got2["realm"])
+	assert.Len(t, got2, 1)
+}
+
+func TestGetBearerTokenErrors(t *testing.T) {
+	s := NewService(config.ProxyConfig{})
+	ctx := context.Background()
+
+	_, err := s.getBearerToken(ctx, "Basic xyz")
+	assert.Contains(t, err.Error(), "unsupported auth challenge")
+
+	_, err = s.getBearerToken(ctx, "Bearer service=\"x\"")
+	assert.Contains(t, err.Error(), "missing bearer realm")
+
+	// Token endpoint returns non-200.
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+	_, err = s.getBearerToken(ctx, `Bearer realm="`+bad.URL+`"`)
+	assert.Contains(t, err.Error(), "token endpoint returned")
+
+	// access_token fallback.
+	at := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"fallback"}`))
+	}))
+	defer at.Close()
+	tok, err := s.getBearerToken(ctx, `Bearer realm="`+at.URL+`"`)
+	require.NoError(t, err)
+	assert.Equal(t, "fallback", tok)
+
+	// Missing token in response.
+	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer empty.Close()
+	_, err = s.getBearerToken(ctx, `Bearer realm="`+empty.URL+`"`)
+	assert.Contains(t, err.Error(), "token not present")
+}
+
+func TestRegistryConfigMapping(t *testing.T) {
+	s := NewService(config.ProxyConfig{})
+	for _, reg := range []string{"npm", "nuget", "maven", "go", "helm", "cargo", "rubygems", "opa", "oci"} {
+		_, ok := s.registryConfig(reg)
+		assert.True(t, ok, reg)
+	}
+	_, ok := s.registryConfig("unknown")
+	assert.False(t, ok)
+}
+
+func TestReadContentWithLimitUnbounded(t *testing.T) {
+	s := NewService(config.ProxyConfig{MaxArtifactBytes: 0})
+	data, err := s.readContentWithLimit(strings.NewReader("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), data)
+}

--- a/internal/registry/upstream/upstream_test.go
+++ b/internal/registry/upstream/upstream_test.go
@@ -196,8 +196,7 @@ func TestFetchBuildURLError(t *testing.T) {
 }
 
 func TestFetchOCIBearerFlow(t *testing.T) {
-	var tokenSrv *httptest.Server
-	tokenSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "myservice", r.URL.Query().Get("service"))
 		_, _ = w.Write([]byte(`{"token":"abc123"}`))
 	}))

--- a/internal/storage/cloud/cloud_test.go
+++ b/internal/storage/cloud/cloud_test.go
@@ -1,0 +1,70 @@
+package cloud
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lgulliver/lodestone/pkg/config"
+)
+
+func TestNewS3StorageValidation(t *testing.T) {
+	_, err := NewS3Storage(&config.StorageConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bucket")
+
+	_, err = NewS3Storage(&config.StorageConfig{S3: config.S3StorageConfig{Bucket: "b"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "region")
+}
+
+func TestNewS3StorageHappyPath(t *testing.T) {
+	// LoadDefaultConfig + client construction do not require network access.
+	s, err := NewS3Storage(&config.StorageConfig{S3: config.S3StorageConfig{
+		Bucket:         "b",
+		Region:         "us-east-1",
+		AccessKey:      "ak",
+		SecretKey:      "sk",
+		Endpoint:       "http://localhost:9000",
+		ForcePathStyle: true,
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, "b", s.bucket)
+}
+
+func TestNewAzureBlobStorageValidation(t *testing.T) {
+	_, err := NewAzureBlobStorage(&config.StorageConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "container")
+
+	// Container set but no creds and no connection string.
+	_, err = NewAzureBlobStorage(&config.StorageConfig{Azure: config.AzureStorageConfig{Container: "c"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account name/key or connection string")
+}
+
+func TestIsS3NotFound(t *testing.T) {
+	assert.True(t, isS3NotFound(&smithy.GenericAPIError{Code: "NoSuchKey"}))
+	assert.True(t, isS3NotFound(&smithy.GenericAPIError{Code: "NotFound"}))
+	assert.True(t, isS3NotFound(&smithy.GenericAPIError{Code: "NoSuchBucket"}))
+	assert.False(t, isS3NotFound(&smithy.GenericAPIError{Code: "AccessDenied"}))
+	assert.False(t, isS3NotFound(errors.New("plain error")))
+}
+
+func TestIsAzureNotFound(t *testing.T) {
+	assert.True(t, isAzureNotFound(&azcore.ResponseError{StatusCode: 404}))
+	assert.True(t, isAzureNotFound(&azcore.ResponseError{ErrorCode: string(bloberror.BlobNotFound)}))
+	assert.False(t, isAzureNotFound(&azcore.ResponseError{StatusCode: 500}))
+	assert.False(t, isAzureNotFound(errors.New("plain error")))
+}
+
+func TestIsAzureContainerExists(t *testing.T) {
+	assert.True(t, isAzureContainerExists(&azcore.ResponseError{ErrorCode: string(bloberror.ContainerAlreadyExists)}))
+	assert.False(t, isAzureContainerExists(&azcore.ResponseError{ErrorCode: "Other"}))
+	assert.False(t, isAzureContainerExists(errors.New("plain error")))
+}

--- a/pkg/config/helpers_test.go
+++ b/pkg/config/helpers_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabaseURL(t *testing.T) {
+	d := &DatabaseConfig{Host: "h", Port: 5432, User: "u", Password: "p", DBName: "db", SSLMode: "disable"}
+	assert.Equal(t, "host=h port=5432 user=u password=p dbname=db sslmode=disable", d.DatabaseURL())
+}
+
+func TestRedisAddr(t *testing.T) {
+	r := &RedisConfig{Host: "localhost", Port: 6379}
+	assert.Equal(t, "localhost:6379", r.RedisAddr())
+}
+
+func TestSetupLogging(t *testing.T) {
+	// Exercises each level branch and both format branches; no panics expected.
+	for _, lvl := range []string{"debug", "info", "warn", "error", "other"} {
+		(&LoggingConfig{Level: lvl, Format: "json"}).SetupLogging()
+	}
+	(&LoggingConfig{Level: "info", Format: "console"}).SetupLogging()
+	(&LoggingConfig{Level: "info", Format: "text"}).SetupLogging()
+}
+
+func TestInitLogger(t *testing.T) {
+	InitLogger() // should not panic
+}
+
+func TestGetEnvDuration(t *testing.T) {
+	t.Setenv("TEST_DUR", "2s")
+	assert.Equal(t, 2*time.Second, getEnvDuration("TEST_DUR", time.Minute))
+
+	t.Setenv("TEST_DUR_BAD", "notaduration")
+	assert.Equal(t, time.Minute, getEnvDuration("TEST_DUR_BAD", time.Minute))
+
+	assert.Equal(t, time.Hour, getEnvDuration("TEST_DUR_UNSET", time.Hour))
+}
+
+func TestGetEnvHelpers(t *testing.T) {
+	t.Setenv("S", "val")
+	assert.Equal(t, "val", getEnv("S", "def"))
+	assert.Equal(t, "def", getEnv("UNSET_S", "def"))
+
+	t.Setenv("I", "10")
+	assert.Equal(t, 10, getEnvInt("I", 1))
+	t.Setenv("I_BAD", "x")
+	assert.Equal(t, 1, getEnvInt("I_BAD", 1))
+
+	t.Setenv("I64", "100")
+	assert.EqualValues(t, 100, getEnvInt64("I64", 1))
+	t.Setenv("I64_BAD", "x")
+	assert.EqualValues(t, 1, getEnvInt64("I64_BAD", 1))
+
+	t.Setenv("B", "true")
+	assert.True(t, getEnvBool("B", false))
+	t.Setenv("B_BAD", "x")
+	assert.False(t, getEnvBool("B_BAD", false))
+}
+
+func TestGetStorageEnv(t *testing.T) {
+	assert.Equal(t, "def", getStorageEnv("P", "S", "T", "def"))
+
+	t.Setenv("T3", "tertiary")
+	assert.Equal(t, "tertiary", getStorageEnv("P3", "S3", "T3", "def"))
+
+	t.Setenv("S2", "secondary")
+	assert.Equal(t, "secondary", getStorageEnv("P2", "S2", "T2", "def"))
+
+	t.Setenv("P1", "primary")
+	assert.Equal(t, "primary", getStorageEnv("P1", "S1", "T1", "def"))
+}

--- a/pkg/utils/crypto_test.go
+++ b/pkg/utils/crypto_test.go
@@ -1,0 +1,77 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateAndValidateJWT(t *testing.T) {
+	userID := uuid.New()
+	secret := "test-secret"
+
+	token, err := GenerateJWT(userID, secret, time.Hour)
+	require.NoError(t, err)
+	assert.NotEmpty(t, token)
+
+	got, err := ValidateJWT(token, secret)
+	require.NoError(t, err)
+	assert.Equal(t, userID, got)
+}
+
+func TestValidateJWTWrongSecret(t *testing.T) {
+	token, err := GenerateJWT(uuid.New(), "right", time.Hour)
+	require.NoError(t, err)
+	_, err = ValidateJWT(token, "wrong")
+	assert.Error(t, err)
+}
+
+func TestValidateJWTExpired(t *testing.T) {
+	token, err := GenerateJWT(uuid.New(), "s", -time.Hour)
+	require.NoError(t, err)
+	_, err = ValidateJWT(token, "s")
+	assert.Error(t, err)
+}
+
+func TestValidateJWTMalformed(t *testing.T) {
+	_, err := ValidateJWT("not.a.jwt", "s")
+	assert.Error(t, err)
+}
+
+func TestComputeSHA256(t *testing.T) {
+	// Known vector for empty string.
+	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", ComputeSHA256([]byte("")))
+}
+
+func TestComputeSHA1(t *testing.T) {
+	assert.Equal(t, "da39a3ee5e6b4b0d3255bfef95601890afd80709", ComputeSHA1([]byte("")))
+}
+
+func TestComputeSHA256FromReader(t *testing.T) {
+	got, err := ComputeSHA256FromReader(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Equal(t, ComputeSHA256([]byte("")), got)
+
+	got, err = ComputeSHA256FromReader(strings.NewReader("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, ComputeSHA256([]byte("hello")), got)
+}
+
+func TestComputeSHA1FromReader(t *testing.T) {
+	got, err := ComputeSHA1FromReader(strings.NewReader("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, ComputeSHA1([]byte("hello")), got)
+}
+
+func TestDecodeBase64(t *testing.T) {
+	got, err := DecodeBase64("aGVsbG8=")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), got)
+
+	_, err = DecodeBase64("!!!not base64!!!")
+	assert.Error(t, err)
+}

--- a/pkg/utils/semver_test.go
+++ b/pkg/utils/semver_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortVersions(t *testing.T) {
+	in := []string{"1.0.0", "2.1.0", "1.5.0", "bogus", "2.0.0"}
+	got := SortVersions(in)
+	// Invalid skipped; latest first.
+	assert.Equal(t, []string{"2.1.0", "2.0.0", "1.5.0", "1.0.0"}, got)
+}
+
+func TestSortVersionsAscending(t *testing.T) {
+	got := SortVersionsAscending([]string{"2.0.0", "1.0.0", "1.5.0"})
+	assert.Equal(t, []string{"1.0.0", "1.5.0", "2.0.0"}, got)
+}
+
+func TestGetLatestVersion(t *testing.T) {
+	assert.Equal(t, "", GetLatestVersion(nil))
+	assert.Equal(t, "3.0.0", GetLatestVersion([]string{"1.0.0", "3.0.0", "2.0.0"}))
+	// All invalid → falls back to first original.
+	assert.Equal(t, "notaver", GetLatestVersion([]string{"notaver", "alsobad"}))
+}
+
+func TestIsPrerelease(t *testing.T) {
+	assert.True(t, IsPrerelease("1.0.0-beta.1"))
+	assert.False(t, IsPrerelease("1.0.0"))
+	assert.False(t, IsPrerelease("invalid")) // conservative false
+}
+
+func TestSortSemver(t *testing.T) {
+	versions := []string{"2.0.0", "1.0.0", "1.5.0"}
+	SortSemver(versions)
+	assert.Equal(t, []string{"1.0.0", "1.5.0", "2.0.0"}, versions)
+}
+
+func TestCompareVersions(t *testing.T) {
+	assert.Equal(t, -1, CompareVersions("1.0.0", "2.0.0"))
+	assert.Equal(t, 0, CompareVersions("1.0.0", "1.0.0"))
+	assert.Equal(t, 1, CompareVersions("2.0.0", "1.0.0"))
+	assert.Equal(t, 2, CompareVersions("bad", "1.0.0"))
+	assert.Equal(t, 2, CompareVersions("1.0.0", "bad"))
+}


### PR DESCRIPTION
## Summary
- Adds happy/negative/edge-path tests across the api-gateway route handlers (npm, nuget, maven, go, helm, cargo, opa, rubygems, oci, auth, admin, ownership) via an end-to-end harness over sqlite + local storage, plus unit tests for registry formats, upstream proxy, storage, metadata, auth, config, and utils.
- Fixes six real defects the new tests surfaced:
  - **ownership**: `RemoveOwner` checks the target's role before the last-owner guard, so removing a maintainer/contributor from a single-owner package no longer fails.
  - **rubygems**: info/versions routes `:name.json` bound the param under key `name.json`; switched to `:name` + `.json` strip so the handlers see the gem name (was always 400).
  - **registry**: `Service.Delete` treats an empty version as a whole-package delete, making npm unpublish work instead of always 500.
  - **oci**: push now records the uploader as repository owner (blob + manifest), so deletes are no longer always 403; manifest PUT records the artifact from its real bytes so pushes appear in `tags/list` and `_catalog`.
  - **maven**: `handleMavenUpload` parses the path the same way the read handlers do, so a PUT artifact is fetchable via GET.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all packages pass
- [x] Coverage gate scope (`./internal/storage ./internal/registry/registries/maven`) at 82.7% (>= 80% floor)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)